### PR TITLE
BatteryHealth: Allow it to be hidden with overlay

### DIFF
--- a/res/values/evolution_config.xml
+++ b/res/values/evolution_config.xml
@@ -34,4 +34,6 @@
     <string name="config_batCurCap"></string>
     <string name="config_batDesCap"></string>
     <string name="config_batChargeCycle"></string>
+    <bool name="config_supportBatteryHealth">false</bool>
+
 </resources>

--- a/res/values/evolution_config.xml
+++ b/res/values/evolution_config.xml
@@ -34,6 +34,5 @@
     <string name="config_batCurCap"></string>
     <string name="config_batDesCap"></string>
     <string name="config_batChargeCycle"></string>
-    <bool name="config_supportBatteryHealth">false</bool>
-
+    <bool name="config_supportBatteryHealth">true</bool>
 </resources>

--- a/res/values/evolution_symbols.xml
+++ b/res/values/evolution_symbols.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2019-2020 The Evolution X Project
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+         http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Smart Charging -->
+    <java-symbol type="bool" name="config_supportBatteryHealth" />
+</resources>

--- a/src/com/android/settings/fuelgauge/PowerUsageSummary.java
+++ b/src/com/android/settings/fuelgauge/PowerUsageSummary.java
@@ -293,6 +293,20 @@ public class PowerUsageSummary extends PowerUsageBase implements OnLongClickList
         if (!getResources().getBoolean(com.android.internal.R.bool.config_SmartChargingAvailable)) {
             getPreferenceScreen().removePreference(mSmartChargingPref);
         }
+
+        // Check availability of Battery Health
+        Preference mDesignedHealthPref = (Preference) findPreference(KEY_DESIGNED_BATTERY_CAPACITY);
+        if (!getResources().getBoolean(R.bool.config_supportBatteryHealth)) {
+            getPreferenceScreen().removePreference(mDesignedHealthPref);
+        }
+        Preference mCurrentHealthPref = (Preference) findPreference(KEY_CURRENT_BATTERY_CAPACITY);
+        if (!getResources().getBoolean(R.bool.config_supportBatteryHealth)) {
+            getPreferenceScreen().removePreference(mCurrentHealthPref);
+        }
+        Preference mCyclesHealthPref = (Preference) findPreference(KEY_BATTERY_CHARGE_CYCLES);
+        if (!getResources().getBoolean(R.bool.config_supportBatteryHealth)) {
+            getPreferenceScreen().removePreference(mCyclesHealthPref);
+        }
     }
 
     @Override


### PR DESCRIPTION
* Allows a device maintainer to show/hide the BatteryHealth preference in Power Settings.
* Helps certain OnePlus devices with unreliable sys nodes
* Enable it by default