### PR TITLE
Settings: Make lockscreen timeout configurable [2/2]

### DIFF
--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -534,4 +534,8 @@
     <string name="global_vpn_summary">Force all traffic on the device through this VPN, including work profile and other users.</string>
     <string name="global_vpn_summary_on">Force all traffic on the device through this VPN, including work profile and other users. Note: When enabled, you will not be able to use a separate VPN in a work profile or other users</string>
     <string name="global_vpn_summary_any_vpn_active">You need to disable all active VPN connections first to enable this</string>
+
+    <!-- Lockscreen timeout -->
+    <string name="lockscreen_timeout_title">Lockscreen timeout</string>
+
 </resources>

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -64,6 +64,13 @@
             android:fragment="com.android.settings.display.ScreenTimeoutSettings"
             settings:controller="com.android.settings.display.ScreenTimeoutPreferenceController"/>
 
+        <com.evolution.settings.preference.SystemSettingListPreference
+            android:key="lockscreen_timeout"
+            android:title="@string/lockscreen_timeout_title"
+            android:entries="@array/screen_timeout_entries"
+            android:entryValues="@array/screen_timeout_values"
+            android:defaultValue="15000" />
+
         <SwitchPreference
             android:key="pocket_judge"
             android:title="@string/pocket_judge_title"

--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -32,6 +32,7 @@ import com.android.settings.display.ScreenSaverPreferenceController;
 import com.android.settings.display.ShowOperatorNamePreferenceController;
 import com.android.settings.display.TapToWakePreferenceController;
 import com.android.settings.display.ThemePreferenceController;
+import com.android.settings.display.TimeoutLockscreenPreferenceController;
 import com.android.settings.display.VrDisplayPreferenceController;
 import com.android.settings.search.BaseSearchIndexProvider;
 import com.android.settingslib.core.AbstractPreferenceController;
@@ -50,6 +51,7 @@ public class DisplaySettings extends DashboardFragment {
     public static final String KEY_PROXIMITY_ON_WAKE = "proximity_on_wake";
     private static final String KEY_HIGH_TOUCH_POLLING_RATE = "high_touch_polling_rate_enable";
     private static final String KEY_HIGH_TOUCH_SENSITIVITY = "high_touch_sensitivity_enable";
+    private static final String KEY_LOCKSCREEN_TIMEOUT = "lockscreen_timeout";
 
     @Override
     public int getMetricsCategory() {
@@ -99,6 +101,7 @@ public class DisplaySettings extends DashboardFragment {
         controllers.add(new PocketJudgePreferenceController(context));
         controllers.add(new ScreenSaverPreferenceController(context));
         controllers.add(new TapToWakePreferenceController(context));
+        controllers.add(new TimeoutLockscreenPreferenceController(context, KEY_LOCKSCREEN_TIMEOUT));
         controllers.add(new VrDisplayPreferenceController(context));
         controllers.add(new ShowOperatorNamePreferenceController(context));
         controllers.add(new ThemePreferenceController(context));

--- a/src/com/android/settings/display/TimeoutLockscreenPreferenceController.java
+++ b/src/com/android/settings/display/TimeoutLockscreenPreferenceController.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.android.settings.display;
+
+import static android.provider.Settings.System.LOCKSCREEN_TIMEOUT;
+
+import android.content.Context;
+import android.provider.Settings;
+
+import androidx.preference.Preference;
+
+import com.android.settings.R;
+import com.android.settings.core.PreferenceControllerMixin;
+import com.android.settingslib.core.AbstractPreferenceController;
+
+import com.evolution.settings.preference.SystemSettingListPreference;
+
+public class TimeoutLockscreenPreferenceController extends AbstractPreferenceController implements
+        PreferenceControllerMixin, Preference.OnPreferenceChangeListener {
+
+    private static final String TAG = "TimeoutLockscreenPrefContr";
+
+    /** If there is no setting in the provider, use this. */
+    public static final int FALLBACK_SCREEN_TIMEOUT_VALUE = 15000;
+
+    private final String mLockScreenTimeoutKey;
+
+    public TimeoutLockscreenPreferenceController(Context context, String key) {
+        super(context);
+        mLockScreenTimeoutKey = key;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return mLockScreenTimeoutKey;
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        final SystemSettingListPreference systemSettingsListPreference = (SystemSettingListPreference) preference;
+        final long currentTimeout = Settings.System.getLong(mContext.getContentResolver(),
+                LOCKSCREEN_TIMEOUT, FALLBACK_SCREEN_TIMEOUT_VALUE);
+        systemSettingsListPreference.setValue(String.valueOf(currentTimeout));
+        updateTimeoutPreferenceDescription(systemSettingsListPreference,
+                Long.parseLong(systemSettingsListPreference.getValue()));
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        try {
+            int value = Integer.parseInt((String) newValue);
+            Settings.System.putInt(mContext.getContentResolver(), LOCKSCREEN_TIMEOUT, value);
+            updateTimeoutPreferenceDescription((SystemSettingListPreference) preference, value);
+        } catch (NumberFormatException e) { }
+        return true;
+    }
+
+    public static CharSequence getTimeoutDescription(
+            long currentTimeout, CharSequence[] entries, CharSequence[] values) {
+        if (currentTimeout < 0 || entries == null || values == null
+                || values.length != entries.length) {
+            return null;
+        }
+
+        for (int i = 0; i < values.length; i++) {
+            long timeout = Long.parseLong(values[i].toString());
+            if (currentTimeout == timeout) {
+                return entries[i];
+            }
+        }
+        return null;
+    }
+
+    private void updateTimeoutPreferenceDescription(SystemSettingListPreference preference,
+                                                    long currentTimeout) {
+        final CharSequence[] entries = preference.getEntries();
+        final CharSequence[] values = preference.getEntryValues();
+        final String summary;
+
+        final CharSequence timeoutDescription = getTimeoutDescription(
+                currentTimeout, entries, values);
+        summary = timeoutDescription == null
+                ? ""
+                : mContext.getString(R.string.screen_timeout_summary, timeoutDescription);
+        preference.setSummary(summary);
+    }
+}


### PR DESCRIPTION
Modeled after the screen timeout, this will control the lockscreen timeout.

Change-Id: I5e095ee1c2fa59ab715964ca7ac0cd2f4a4b3ab7