### PR TITLE
Settings: Fix setting device name based on market name

### DIFF
--- a/src/com/android/settings/deviceinfo/DeviceNamePreferenceController.java
+++ b/src/com/android/settings/deviceinfo/DeviceNamePreferenceController.java
@@ -81,9 +81,16 @@ public class DeviceNamePreferenceController extends BasePreferenceController
     private void initializeDeviceName() {
         String deviceName = Settings.Global.getString(mContext.getContentResolver(),
                 Settings.Global.DEVICE_NAME);
-        if (deviceName == null)
-            deviceName = Build.MODEL;
-        mDeviceName = SystemProperties.get(KEY_MARKET_NAME_PROP, deviceName);
+
+        // Try using market name if there is not set device name
+        if (deviceName == null) {
+            deviceName = SystemProperties.get(KEY_MARKET_NAME_PROP, null);
+        
+            // If market name is not available, fallback to device model
+            if (deviceName == null)
+                deviceName = Build.MODEL;
+        }
+        mDeviceName = deviceName;
     }
 
     @Override


### PR DESCRIPTION
The current code for setting device name based on market name is incorrect; this means that if the required property exists on a device, it will always use the market name regardless if the user has customized their device name.

Fix this by checking if the market name prop exists if and only if there is no customized device name, then falling back to the device model if said prop doesn't exist.