### PR TITLE
Settings: Battery stats: read battery health more robust

### DIFF
--- a/src/com/android/settings/fuelgauge/batteryusage/PowerUsageSummary.java
+++ b/src/com/android/settings/fuelgauge/batteryusage/PowerUsageSummary.java
@@ -391,8 +391,14 @@ public class PowerUsageSummary extends PowerUsageBase implements
             health = readLine(mBatteryHealth);
         } else if (!TextUtils.isEmpty(mBatteryRemainingCapacity) &&
                 !TextUtils.isEmpty(mBatteryDesignCapacity)) {
-            health = String.valueOf(Integer.parseInt(readLine(mBatteryRemainingCapacity)) * 100 /
-                    Integer.parseInt(readLine(mBatteryDesignCapacity)));
+            String batteryRemainingCapacityValue = readLine(mBatteryRemainingCapacity);
+            String batteryDesignCapacityValue = readLine(mBatteryDesignCapacity);
+            if(batteryRemainingCapacityValue != null && batteryDesignCapacityValue != null) {
+                health = String.valueOf(Integer.parseInt(batteryRemainingCapacityValue) * 100 /
+                    Integer.parseInt(batteryDesignCapacityValue));
+            } else {
+                health = null;
+            }
         } else {
             health = null;
         }
@@ -454,7 +460,7 @@ public class PowerUsageSummary extends PowerUsageBase implements
         restartBatteryTipLoader();
     }
 
-    private static String readLine(String filename) {
+    private String readLine(String filename) {
         BufferedReader reader;
         String line = null;
         try {
@@ -464,7 +470,8 @@ public class PowerUsageSummary extends PowerUsageBase implements
             } finally {
                 reader.close();
             }
-        } catch (Exception e) {
+        } catch (IOException e) {
+            Log.e(getLogTag(), "error while reading " + filename, e);
             return null;
         }
         return line;


### PR DESCRIPTION
Previously the app crashed on miatoll (caused by missing sepolicies).
