### PR TITLE
Settings: Use ro.product.device for device codename display

### DIFF
--- a/src/com/android/settings/deviceinfo/firmwareversion/EvolutionXVersionDetailPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/firmwareversion/EvolutionXVersionDetailPreferenceController.java
@@ -45,7 +45,7 @@ public class EvolutionXVersionDetailPreferenceController extends BasePreferenceC
 
     private static final String KEY_EVOLUTION_BUILD_VERSION_PROP = "org.evolution.build_version";
     private static final String KEY_EVOLUTION_CODENAME_PROP = "org.evolution.build_codename";
-    private static final String KEY_EVOLUTION_DEVICE_PROP = "org.evolution.device";
+    private static final String KEY_EVOLUTION_DEVICE_PROP = "ro.product.device";
     private static final String KEY_EVOLUTION_RELEASE_TYPE_PROP = "org.evolution.build_type";
     private static final String KEY_EVOLUTION_VERSION_PROP = "org.evolution.version.display";
 


### PR DESCRIPTION
* Displays actual device codename in About Phone rather than the regular lunch target device which could be either a unified codename or single device eg. ginkgo/vayu separates from willow/bhima respectively.