### PR TITLE
FIX: Adding missing strings for power_usage_summary

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -5224,6 +5224,27 @@
                 android:value="com.android.settings.development.WirelessDebuggingFragment"/>
         </activity>
 
+        <!-- Provide direct entry into Dev settings - Running Services -->
+        <activity android:name="Settings$DevRunningServicesActivity"
+                android:label="@string/runningservices_settings_title"
+                android:theme="@style/Theme.SubSettingsBase"
+                android:enabled="true"
+                android:exported="true"
+                android:excludeFromRecents="true"
+                android:taskAffinity="com.android.settings"
+                android:parentActivityName="Settings">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.MONKEY" />
+                <category android:name="android.intent.category.VOICE_LAUNCH" />
+            </intent-filter>
+            <meta-data android:name="com.android.settings.FRAGMENT_CLASS"
+                android:value="com.android.settings.applications.RunningServices" />
+            <meta-data android:name="com.android.settings.PRIMARY_PROFILE_CONTROLLED"
+                android:value="true" />
+        </activity>
+
         <!-- This is the longest AndroidManifest.xml ever. -->
     </application>
 </manifest>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -5211,6 +5211,19 @@
                 android:value="com.android.settings.fuelgauge.sleepmode.SleepMode" />
         </activity>
 
+        <activity
+            android:name=".Settings$WirelessDebuggingActivity"
+            android:label="@string/adb_wireless_settings"
+            android:exported="true"
+            android:icon="@drawable/tile_icon_debugging_wireless">
+            <intent-filter android:priority="1">
+                <action android:name="android.settings.WIRELESS_DEBUGGING_SETTINGS" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <meta-data android:name="com.android.settings.FRAGMENT_CLASS"
+                android:value="com.android.settings.development.WirelessDebuggingFragment"/>
+        </activity>
+
         <!-- This is the longest AndroidManifest.xml ever. -->
     </application>
 </manifest>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -2593,7 +2593,7 @@
             android:screenOrientation="portrait"/>
 
         <activity android:name=".biometrics.face.FaceEnrollFinish"
-            android:exported="false"
+            android:exported="true"
             android:screenOrientation="portrait"/>
 
         <activity android:name=".biometrics.BiometricHandoffActivity"

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -5130,7 +5130,7 @@
         </activity>
 
         <!-- Changelog Activity -->
-        <activity android:name="com.evolution.settings.about.ChangelogActivity"
+        <activity android:name="com.evolution.settings.fragments.about.ChangelogActivity"
             android:label="@string/changelog_evolution_title"
             android:parentActivityName="com.android.settings"
             android:theme="@style/Theme.SubSettingsBase"
@@ -5190,7 +5190,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
             <meta-data android:name="com.android.settings.FRAGMENT_CLASS"
-                android:value="com.evolution.settings.fragments.SmartPixels" />
+                android:value="com.android.settings.display.SmartPixels" />
         </activity>
 
         <!-- Sleep Mode -->

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1502,6 +1502,26 @@
         </activity>
 
         <activity
+            android:name="Settings$RefreshRateSettingsActivity"
+            android:label="@string/refresh_rate_title"
+            android:exported="true">
+            <intent-filter android:priority="32">
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.android.settings.SHORTCUT" />
+            </intent-filter>
+            <intent-filter android:priority="1">
+                <action android:name="android.settings.REFRESH_RATE_SETTINGS" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <meta-data android:name="com.android.settings.FRAGMENT_CLASS"
+                android:value="com.android.settings.display.RefreshRateSettings" />
+            <meta-data android:name="com.android.settings.HIGHLIGHT_MENU_KEY"
+                       android:value="@string/menu_key_display"/>
+            <meta-data android:name="com.android.settings.PRIMARY_PROFILE_CONTROLLED"
+                android:value="true" />
+        </activity>
+
+        <activity
             android:name="Settings$NightDisplaySuggestionActivity"
             android:enabled="@*android:bool/config_nightDisplayAvailable"
             android:exported="true"

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1482,6 +1482,26 @@
         </activity>
 
         <activity
+            android:name="Settings$DcDimmingSettingsActivity"
+            android:label="@string/dc_dimming_title"
+            android:exported="true">
+            <intent-filter android:priority="32">
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.android.settings.SHORTCUT" />
+            </intent-filter>
+            <intent-filter android:priority="1">
+                <action android:name="android.settings.DC_DIMMING_SETTINGS" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <meta-data android:name="com.android.settings.FRAGMENT_CLASS"
+                android:value="com.android.settings.display.DcDimmingSettings" />
+            <meta-data android:name="com.android.settings.HIGHLIGHT_MENU_KEY"
+                       android:value="@string/menu_key_display"/>
+            <meta-data android:name="com.android.settings.PRIMARY_PROFILE_CONTROLLED"
+                android:value="true" />
+        </activity>
+
+        <activity
             android:name="Settings$NightDisplaySuggestionActivity"
             android:enabled="@*android:bool/config_nightDisplayAvailable"
             android:exported="true"

--- a/res/drawable/ic_brightness_thumb.xml
+++ b/res/drawable/ic_brightness_thumb.xml
@@ -1,0 +1,27 @@
+<!--
+Copyright (C) 2014 The Android Open Source Project
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="28.0dp"
+        android:height="28.0dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:pathData="m18.250000,12.000000a6.250000,6.250000 0.000000,1.000000 1.000000,-12.500000 0.000000,6.250000 6.250000,0.000000 1.000000,1.000000 12.500000,0.000000z"
+        android:fillColor="?android:attr/colorPrimary" />
+    <path
+        android:fillColor="?android:attr/colorControlNormal"
+        android:pathData="M20.000000,8.700000L20.000000,4.000000L15.300000,4.000000L12.000000,0.700000 8.700000,4.000000L4.000000,4.000000L4.000000,8.700000L0.700000,12.000000 4.000000,15.300000L4.000000,20.000000L8.700000,20.000000L12.000000,23.299999 15.300000,20.000000L20.000000,20.000000L20.000000,15.300000L23.299999,12.000000 20.000000,8.700000zM12.000000,18.000000C8.700000,18.000000 6.000000,15.300000 6.000000,12.000000 6.000000,8.700000 8.700000,6.000000 12.000000,6.000000c3.300000,0.000000 6.000000,2.700000 6.000000,6.000000 0.000000,3.300000 -2.700000,6.000000 -6.000000,6.000000zM12.000000,8.000000c-2.200000,0.000000 -4.000000,1.800000 -4.000000,4.000000 0.000000,2.200000 1.800000,4.000000 4.000000,4.000000 2.200000,0.000000 4.000000,-1.800000 4.000000,-4.000000 0.000000,-2.200000 -1.800000,-4.000000 -4.000000,-4.000000z"/>
+</vector>

--- a/res/drawable/ic_menu_add.xml
+++ b/res/drawable/ic_menu_add.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2015 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    android:tint="?android:attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/res/drawable/ic_settings_backup_restore.xml
+++ b/res/drawable/ic_settings_backup_restore.xml
@@ -1,0 +1,25 @@
+<!--
+    Copyright (C) 2017 The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0"
+        android:tint="?android:attr/colorControlNormal">
+    <path
+        android:pathData="M14,12c0,-1.1 -0.9,-2 -2,-2s-2,0.9 -2,2 0.9,2 2,2 2,-0.9 2,-2zM12,3c-4.97,0 -9,4.03 -9,9L0,12l4,4 4,-4L5,12c0,-3.87 3.13,-7 7,-7s7,3.13 7,7 -3.13,7 -7,7c-1.51,0 -2.91,-0.49 -4.06,-1.3l-1.42,1.44C8.04,20.3 9.94,21 12,21c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9z"
+        android:fillColor="#FFFFFFFF"/>
+</vector>

--- a/res/layout/dialog_brightness.xml
+++ b/res/layout/dialog_brightness.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2012-2015 The CyanogenMod Project
+     Copyright (C) 2017 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp"
+    android:orientation="vertical">
+
+    <TextView android:id="@+id/brightness_percent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:paddingTop="8dp" />
+
+    <SeekBar
+        android:id="@+id/brightness_seekbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:paddingTop="6dp" />
+
+</LinearLayout>

--- a/res/layout/dialog_light_settings.xml
+++ b/res/layout/dialog_light_settings.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2010 Daniel Nilsson
+     Copyright (C) 2012 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:paddingStart="8dp"
+      android:paddingEnd="8dp"
+      android:scrollbars="vertical"
+      android:scrollbarStyle="outsideOverlay"
+      android:scrollbarDefaultDelayBeforeFade="1500"
+      android:scrollbarAlwaysDrawVerticalTrack="true"
+      android:fillViewport="true">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" >
+
+        <com.evolution.settings.preference.colorpicker.ColorPickerView
+            android:id="@+id/color_picker_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:layout_marginStart="10dp"
+            android:layout_marginEnd="10dp" />
+
+        <LinearLayout
+            android:id="@+id/color_panel_view"
+            android:layout_width="match_parent"
+            android:layout_height="40dp"
+            android:layout_alignStart="@id/color_picker_view"
+            android:layout_alignEnd="@id/color_picker_view"
+            android:layout_below="@id/color_picker_view"
+            android:layout_marginBottom="4dp"
+            android:layout_marginTop="4dp"
+            android:orientation="horizontal" >
+
+            <EditText
+                android:id="@+id/hex_color_input"
+                android:layout_width="0px"
+                android:maxLength="6"
+                android:digits="0123456789ABCDEFabcdef"
+                android:inputType="textNoSuggestions"
+                android:layout_height="match_parent"
+                android:layout_weight="0.5" />
+
+            <com.evolution.settings.preference.colorpicker.ColorPanelView
+                android:id="@+id/color_panel"
+                android:layout_width="0px"
+                android:layout_height="match_parent"
+                android:layout_weight="0.5" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/speed_title_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/color_panel_view"
+            android:layout_marginStart="10dp"
+            android:layout_marginEnd="10dp"
+            android:layout_marginTop="4dp"
+            android:orientation="vertical" >
+
+            <View
+                android:id="@+id/lights_dialog_divider"
+                android:layout_width="match_parent"
+                android:layout_height="2dp"
+                android:background="@android:drawable/divider_horizontal_dark" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/pulse_speed_title"
+                android:textAppearance="?android:attr/textAppearanceSmall" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:paddingBottom="4dip" >
+
+                <Spinner
+                    android:id="@+id/on_spinner"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1" />
+
+                <View
+                    android:layout_width="8dip"
+                    android:layout_height="match_parent" />
+
+                <Spinner
+                    android:id="@+id/off_spinner"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1" />
+            </LinearLayout>
+        </LinearLayout>
+
+    </RelativeLayout>
+</ScrollView>

--- a/res/layout/preference_application_light.xml
+++ b/res/layout/preference_application_light.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2014 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/app_light_pref"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall"
+    android:gravity="center_vertical"
+    android:background="?android:attr/selectableItemBackground">
+
+    <ImageView
+        android:id="@android:id/icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="12dip"
+        android:padding="2dp"
+        android:maxWidth="36dip"
+        android:maxHeight="36dip"
+        android:adjustViewBounds="true"
+        android:layout_gravity="center" />
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:paddingTop="16dip"
+        android:paddingBottom="16dip">
+
+        <TextView
+            android:id="@android:id/title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:singleLine="true"
+            android:textAppearance="@android:style/TextAppearance.Material.Subhead"
+            android:textColor="?android:attr/textColorPrimary"
+            android:ellipsize="marquee"
+            android:fadingEdge="horizontal" />
+
+        <TextView
+            android:id="@android:id/summary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@android:id/title"
+            android:layout_alignStart="@android:id/title"
+            android:visibility="gone"
+            android:textAlignment="viewStart"
+            android:textAppearance="@android:style/TextAppearance.Material.Body1"
+            android:textColor="?android:attr/textColorSecondary"
+            android:maxLines="1" />
+    </RelativeLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" >
+
+        <TextView
+            android:id="@+id/textViewTimeOnValue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:textAppearance="@android:style/TextAppearance.Material.Notification.Line2"
+            android:textColor="?android:attr/textColorSecondary" />
+
+        <TextView
+            android:id="@+id/textViewTimeOffValue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:textAppearance="@android:style/TextAppearance.Material.Notification.Line2"
+            android:textColor="?android:attr/textColorSecondary" />
+    </LinearLayout>
+
+    <ImageView
+        android:id="@+id/light_color"
+        android:layout_width="32dip"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"/>
+
+</LinearLayout>

--- a/res/layout/preference_brightness.xml
+++ b/res/layout/preference_brightness.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2018 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/brightness_pref"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical">
+
+    <TextView
+        android:id="@android:id/title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="start" />
+
+    <TextView
+        android:id="@+id/brightness_percent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="end"
+        android:paddingRight="4dp"
+        android:textColor="?android:attr/textColorSecondary" />
+
+</LinearLayout>

--- a/res/layout/preference_icon_evolution.xml
+++ b/res/layout/preference_icon_evolution.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2006 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<!-- Layout for a Preference in a PreferenceActivity. The
+     Preference is able to place a specific widget for its particular
+     type in the "widget_frame" layout. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/widget_frame"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="56dp"
+    android:gravity="center_vertical"
+    android:paddingEnd="?android:attr/scrollbarSize">
+
+    <ImageView
+        android:id="@android:id/icon"
+        android:layout_width="36dip"
+        android:layout_height="36dip"
+        android:layout_marginStart="6dip"
+        android:layout_marginEnd="6dip"
+        android:layout_gravity="center"
+        android:contentDescription="@null" />
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="2dip"
+        android:layout_marginEnd="6dip"
+        android:layout_marginTop="6dip"
+        android:layout_marginBottom="6dip"
+        android:layout_weight="1">
+
+        <TextView android:id="@android:id/title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:singleLine="true"
+            android:textAppearance="?android:attr/textAppearanceListItem"
+            android:ellipsize="marquee"
+            android:fadingEdge="horizontal" />
+
+        <TextView android:id="@android:id/summary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@android:id/title"
+            android:layout_alignStart="@android:id/title"
+            android:textAppearance="?android:attr/textAppearanceListItemSecondary"
+            android:maxLines="2" />
+
+    </RelativeLayout>
+
+</LinearLayout>

--- a/res/layout/pulse_time_item.xml
+++ b/res/layout/pulse_time_item.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/textViewName"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingStart="4dp"
+    android:paddingEnd="4dp"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp"
+    android:textAppearance="@android:style/TextAppearance.Material.Subhead" >
+
+</TextView>

--- a/res/layout/wifi_network_config.xml
+++ b/res/layout/wifi_network_config.xml
@@ -706,7 +706,7 @@
                      android:layout_height="wrap_content"
                      style="@style/wifi_item_spinner"
                      android:prompt="@string/wifi_privacy_settings"
-                     android:entries="@array/wifi_privacy_entries"/>
+                     android:entries="@array/wifi_privacy_entries_extended"/>
         </LinearLayout>
 
         <LinearLayout

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -1053,6 +1053,12 @@
         <item>Treat as unmetered</item>
     </string-array>
 
+    <string-array name="wifi_privacy_entries_extended">
+        <item>Use per-connection randomized MAC (default)</item>
+        <item>Use per-network randomized MAC</item>
+        <item>Use device MAC</item>
+    </string-array>
+
     <string-array name="wifi_privacy_entries">
         <item>Use randomized MAC (default)</item>
         <item>Use device MAC</item>
@@ -1070,6 +1076,7 @@
     </string-array>
 
     <string-array name="wifi_privacy_values" translatable="false">
+        <item>100</item>
         <item>1</item>
         <item>0</item>
     </string-array>

--- a/res/values/evolution_arrays.xml
+++ b/res/values/evolution_arrays.xml
@@ -219,7 +219,6 @@
         <item>@string/kill_app</item>
         <item>@string/recent_app_toggle</item>
         <item>@string/show_powermenu</item>
-        <item>@string/partial_screenshot</item>
         <item>@string/action_app_switch</item>
         <item>@string/action_forward</item>
         <item>@string/action_menu</item>
@@ -244,7 +243,6 @@
         <item>15</item>
         <item>16</item>
         <item>17</item>
-        <item>18</item>
     </string-array>
 
     <!-- Values for the notification light pulse spinners -->

--- a/res/values/evolution_arrays.xml
+++ b/res/values/evolution_arrays.xml
@@ -201,4 +201,61 @@
         <item>4</item>
         <item>2</item>
     </string-array>
+
+    <!-- Back swipe actions -->
+    <string-array name="swipe_actions_entries" translatable="false">
+        <item>@string/action_nothing</item>
+        <item>@string/action_voice_search</item>
+        <item>@string/action_launch_camera</item>
+        <item>@string/action_flashlight</item>
+        <item>@string/action_app_action</item>
+        <item>@string/action_volume_panel</item>
+        <item>@string/action_screen_off</item>
+        <item>@string/action_screenshot</item>
+        <item>@string/action_notifications</item>
+        <item>@string/action_qs_panel</item>
+        <item>@string/action_clear_notifications</item>
+        <item>@string/action_ringer_modes</item>
+        <item>@string/kill_app</item>
+        <item>@string/recent_app_toggle</item>
+        <item>@string/show_powermenu</item>
+        <item>@string/partial_screenshot</item>
+    </string-array>
+
+    <string-array name="swipe_actions_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+        <item>9</item>
+        <item>10</item>
+        <item>11</item>
+        <item>12</item>
+        <item>13</item>
+        <item>14</item>
+        <item>15</item>
+    </string-array>
+
+    <string-array name="long_back_swipe_timeout_entries">
+       <item>250 ms</item>
+       <item>300 ms</item>
+       <item>500 ms</item>
+       <item>1000 ms</item>
+       <item>1500 ms</item>
+       <item>2000 ms</item>
+    </string-array>
+
+    <string-array name="long_back_swipe_timeout_values" translatable="false">
+       <item>250</item>
+       <item>300</item>
+       <item>500</item>
+       <item>1000</item>
+       <item>1500</item>
+       <item>2000</item>
+    </string-array>
 </resources>

--- a/res/values/evolution_arrays.xml
+++ b/res/values/evolution_arrays.xml
@@ -258,4 +258,39 @@
        <item>1500</item>
        <item>2000</item>
     </string-array>
+
+    <!-- Values for the notification light pulse spinners -->
+    <string-array name="notification_pulse_length_entries" translatable="false">
+        <item>@string/pulse_length_always_on</item>
+        <item>@string/pulse_length_very_short</item>
+        <item>@string/pulse_length_short</item>
+        <item>@string/pulse_length_normal</item>
+        <item>@string/pulse_length_long</item>
+        <item>@string/pulse_length_very_long</item>
+    </string-array>
+
+    <string-array name="notification_pulse_length_values" translatable="false">
+        <item>1</item>
+        <item>250</item>
+        <item>500</item>
+        <item>1000</item>
+        <item>2000</item>
+        <item>5000</item>
+    </string-array>
+
+    <string-array name="notification_pulse_speed_entries" translatable="false">
+        <item>@string/pulse_speed_very_fast</item>
+        <item>@string/pulse_speed_fast</item>
+        <item>@string/pulse_speed_normal</item>
+        <item>@string/pulse_speed_slow</item>
+        <item>@string/pulse_speed_very_slow</item>
+    </string-array>
+
+    <string-array name="notification_pulse_speed_values" translatable="false">
+        <item>250</item>
+        <item>500</item>
+        <item>1000</item>
+        <item>2000</item>
+        <item>5000</item>
+    </string-array>
 </resources>

--- a/res/values/evolution_arrays.xml
+++ b/res/values/evolution_arrays.xml
@@ -220,6 +220,7 @@
         <item>@string/recent_app_toggle</item>
         <item>@string/show_powermenu</item>
         <item>@string/partial_screenshot</item>
+        <item>@string/action_app_switch</item>
     </string-array>
 
     <string-array name="swipe_actions_values" translatable="false">
@@ -239,6 +240,7 @@
         <item>13</item>
         <item>14</item>
         <item>15</item>
+        <item>16</item>
     </string-array>
 
     <!-- Values for the notification light pulse spinners -->

--- a/res/values/evolution_arrays.xml
+++ b/res/values/evolution_arrays.xml
@@ -184,4 +184,21 @@
         <item>900000</item>
         <item>1800000</item>
     </string-array>
+
+    <!-- AOD Schedule -->
+    <string-array name="doze_always_on_auto_mode_entries">
+        <item>@string/disabled</item>
+        <item>@string/night_display_auto_mode_twilight</item>
+        <item>@string/always_on_display_schedule_mixed_sunset</item>
+        <item>@string/always_on_display_schedule_mixed_sunrise</item>
+        <item>@string/night_display_auto_mode_custom</item>
+    </string-array>
+
+    <string-array name="doze_always_on_auto_mode_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>3</item>
+        <item>4</item>
+        <item>2</item>
+    </string-array>
 </resources>

--- a/res/values/evolution_arrays.xml
+++ b/res/values/evolution_arrays.xml
@@ -222,6 +222,7 @@
         <item>@string/partial_screenshot</item>
         <item>@string/action_app_switch</item>
         <item>@string/action_forward</item>
+        <item>@string/action_menu</item>
     </string-array>
 
     <string-array name="swipe_actions_values" translatable="false">
@@ -243,6 +244,7 @@
         <item>15</item>
         <item>16</item>
         <item>17</item>
+        <item>18</item>
     </string-array>
 
     <!-- Values for the notification light pulse spinners -->

--- a/res/values/evolution_arrays.xml
+++ b/res/values/evolution_arrays.xml
@@ -241,24 +241,6 @@
         <item>15</item>
     </string-array>
 
-    <string-array name="long_back_swipe_timeout_entries">
-       <item>250 ms</item>
-       <item>300 ms</item>
-       <item>500 ms</item>
-       <item>1000 ms</item>
-       <item>1500 ms</item>
-       <item>2000 ms</item>
-    </string-array>
-
-    <string-array name="long_back_swipe_timeout_values" translatable="false">
-       <item>250</item>
-       <item>300</item>
-       <item>500</item>
-       <item>1000</item>
-       <item>1500</item>
-       <item>2000</item>
-    </string-array>
-
     <!-- Values for the notification light pulse spinners -->
     <string-array name="notification_pulse_length_entries" translatable="false">
         <item>@string/pulse_length_always_on</item>

--- a/res/values/evolution_arrays.xml
+++ b/res/values/evolution_arrays.xml
@@ -162,4 +162,26 @@
         <item>2</item>
         <item>3</item>
     </string-array>
+
+    <!-- Per-app notification settings: Timeout period in which the app notifications are muted. These are shown in a list dialog. -->
+    <string-array name="app_notification_sound_timeout_entries" translatable="false">
+        <item>@string/app_notification_sound_timeout_value_none</item>
+        <item>@string/app_notification_sound_timeout_value_10_seconds</item>
+        <item>@string/app_notification_sound_timeout_value_30_seconds</item>
+        <item>@string/app_notification_sound_timeout_value_1_minute</item>
+        <item>@string/app_notification_sound_timeout_value_5_minutes</item>
+        <item>@string/app_notification_sound_timeout_value_15_minutes</item>
+        <item>@string/app_notification_sound_timeout_value_30_minutes</item>
+    </string-array>
+
+    <!-- Do not translate. -->
+    <string-array name="app_notification_sound_timeout_values" translatable="false">
+        <item>0</item>
+        <item>10000</item>
+        <item>30000</item>
+        <item>60000</item>
+        <item>300000</item>
+        <item>900000</item>
+        <item>1800000</item>
+    </string-array>
 </resources>

--- a/res/values/evolution_arrays.xml
+++ b/res/values/evolution_arrays.xml
@@ -221,6 +221,7 @@
         <item>@string/show_powermenu</item>
         <item>@string/partial_screenshot</item>
         <item>@string/action_app_switch</item>
+        <item>@string/action_forward</item>
     </string-array>
 
     <string-array name="swipe_actions_values" translatable="false">
@@ -241,6 +242,7 @@
         <item>14</item>
         <item>15</item>
         <item>16</item>
+        <item>17</item>
     </string-array>
 
     <!-- Values for the notification light pulse spinners -->

--- a/res/values/evolution_config.xml
+++ b/res/values/evolution_config.xml
@@ -23,6 +23,9 @@
          but a dedicated one, i.e. not embedded in the power button. -->
     <bool name="config_is_side_fps" translatable="false">false</bool>
 
+    <!-- Whether device supports showing battery charge cycles -->
+    <bool name="config_showBatteryChargeCycles">true</bool>
+
     <!-- Whether to show custom screen resolution settings -->
     <bool name="config_show_custom_screen_resolution_switch">true</bool>
 

--- a/res/values/evolution_config.xml
+++ b/res/values/evolution_config.xml
@@ -22,4 +22,7 @@
     <!-- Indicates whether device has a side mounted fingerprint sensor,
          but a dedicated one, i.e. not embedded in the power button. -->
     <bool name="config_is_side_fps" translatable="false">false</bool>
+
+    <!-- Whether to show custom screen resolution settings -->
+    <bool name="config_show_custom_screen_resolution_switch">true</bool>
 </resources>

--- a/res/values/evolution_config.xml
+++ b/res/values/evolution_config.xml
@@ -38,4 +38,7 @@
     <bool name="def_battery_light_pulse">true</bool>
     <!-- Default value for battery light disabled when fully charged preference -->
     <bool name="def_battery_light_full_charge_disabled">false</bool>
+
+    <!-- Show battery information -->
+    <bool name="config_show_battery_info" translatable="false">true</bool>
 </resources>

--- a/res/values/evolution_config.xml
+++ b/res/values/evolution_config.xml
@@ -10,6 +10,9 @@
     <!-- Device specific doze package -->
     <string name="config_customDozePackage" translatable="false"></string>
 
+    <!-- Whether to show min/max refresh rate in display settings -->
+    <bool name="config_show_refresh_rate_controls">false</bool>
+
     <!-- Fingerprint -->
     <bool name="config_is_front_facing_fps" translatable="false">false</bool>
 

--- a/res/values/evolution_config.xml
+++ b/res/values/evolution_config.xml
@@ -28,4 +28,11 @@
 
     <!-- Whether device supports increased touch sensitvity -->
     <bool name="config_supportTouchPollingMode">false</bool>
+
+    <!-- Default value for battery_light_enabled preference -->
+    <bool name="def_battery_light_enabled">true</bool>
+    <!-- Default value for battery light pulse -->
+    <bool name="def_battery_light_pulse">true</bool>
+    <!-- Default value for battery light disabled when fully charged preference -->
+    <bool name="def_battery_light_full_charge_disabled">false</bool>
 </resources>

--- a/res/values/evolution_config.xml
+++ b/res/values/evolution_config.xml
@@ -25,4 +25,7 @@
 
     <!-- Whether to show custom screen resolution settings -->
     <bool name="config_show_custom_screen_resolution_switch">true</bool>
+
+    <!-- Whether device supports increased touch sensitvity -->
+    <bool name="config_supportTouchPollingMode">false</bool>
 </resources>

--- a/res/values/evolution_dimens.xml
+++ b/res/values/evolution_dimens.xml
@@ -12,4 +12,6 @@
 
     <!-- Dimensions for Contextual Card -->
     <dimen name="contextual_card_content_padding">13dp</dimen>
+
+    <dimen name="package_list_padding_top">16dp</dimen>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -462,4 +462,8 @@
     <string name="always_on_display_schedule_sunrise">Sunrise</string>        
     <string name="always_on_display_schedule_mixed_sunset">Turns on from sunset till a time</string>
     <string name="always_on_display_schedule_mixed_sunrise">Turns on from a time till sunrise</string>
+
+    <!-- Ambient wake toggles -->
+    <string name="doze_gesture_ambient_title">Show Ambient</string>
+    <string name="doze_gesture_ambient_summary">Show Ambient Display instead of fully waking the screen up</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -453,4 +453,13 @@
 
     <!-- Running services - Background processes tab -->
     <string name="background_processes_settings_title">Background processes</string>
+
+    <!-- Extra dim schedule -->
+    <string name="extra_dim_schedule_title">Schedule</string>
+    <string name="disabled">Disabled</string>
+    <string name="always_on_display_schedule_title">Always on display schedule</string>
+    <string name="always_on_display_schedule_sunset">Sunset</string>
+    <string name="always_on_display_schedule_sunrise">Sunrise</string>        
+    <string name="always_on_display_schedule_mixed_sunset">Turns on from sunset till a time</string>
+    <string name="always_on_display_schedule_mixed_sunrise">Turns on from a time till sunrise</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -582,7 +582,8 @@
     <string name="battery_light_list_title">Colors</string>
     <string name="battery_light_low_color_title">Battery low</string>
     <string name="battery_light_medium_color_title">Charging</string>
-    <string name="battery_light_full_color_title">Fully charged</string>
+    <string name="battery_light_full_color_title">Charged (90%)</string>
+    <string name="battery_light_really_full_color_title">Charged (100%)</string>
     <string name="battery_light_brightness_normal" translatable="false">@string/light_brightness_normal</string>
     <string name="battery_light_brightness_zen" translatable="false">@string/light_brightness_zen</string>
 

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -433,6 +433,7 @@
     <string name="display_rotation_title">Rotation settings</string>
     <string name="display_rotation_enabled">Auto-rotation is enabled</string>
     <string name="display_rotation_disabled">Auto-rotation is disabled</string>
+    <string name="display_lockscreen_rotation_title">Lock screen</string>
     <string name="display_rotation_unit">degrees</string>
     <string name="display_rotation_category_title">Rotation modes</string>
     <string name="display_rotation_0_title">0 degrees</string>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -535,7 +535,6 @@
     <string name="kill_app">Kill foreground app</string>
     <string name="recent_app_toggle">Switch recent app</string>
     <string name="show_powermenu">Show Power menu</string>
-    <string name="partial_screenshot">Partial screenshot</string>
     <string name="action_forward">Go forward</string>
 
     <!-- Long swipe gestures -->

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -612,4 +612,39 @@
     <string name="led_notification_title">Light settings</string>
     <string name="led_notification_text">LED light enabled by settings</string>
     <string name="notification_light_add_apps_empty_summary">To add per app control, activate \'%1$s\' and press \'Add\'</string>
+
+    <!-- Battery Info: Technology -->
+    <string name="battery_technology">Technology</string>
+    <string name="battery_technology_not_available" translatable="false">@string/battery_cycle_count_not_available</string>
+
+    <!-- Battery Info: Health -->
+    <string name="battery_health">Health</string>
+    <string name="battery_health_good">Good</string>
+    <string name="battery_health_overheat">Overheat</string>
+    <string name="battery_health_dead">Dead</string>
+    <string name="battery_health_over_voltage">Over voltage</string>
+    <string name="battery_health_unspecified_failure">Unspecified failure</string>
+    <string name="battery_health_cold">Cold</string>
+    <string name="battery_health_unknown">Unknown</string>
+
+    <!-- Battery Info: Temperature -->
+    <string name="battery_temperature">Temperature</string>
+    <string name="battery_temperature_not_available" translatable="false">@string/battery_cycle_count_not_available</string>
+
+    <!-- Battery Info: Voltage -->
+    <string name="battery_voltage">Voltage</string>
+    <string name="battery_voltage_not_available" translatable="false">@string/battery_cycle_count_not_available</string>
+
+    <!-- Battery Info: Charge Counter -->
+    <string name="battery_charge_counter_summary" translatable="false">%1$d mAh</string>
+
+    <!-- Battery Info: Design Capacity -->
+    <string name="battery_design_capacity">Design capacity</string>
+    <string name="battery_design_capacity_summary" translatable="false">%1$d mAh</string>
+    <string name="battery_design_capacity_not_available" translatable="false">@string/battery_cycle_count_not_available</string>
+
+    <!-- Battery Info: Maximum Capacity -->
+    <string name="battery_maximum_capacity">Maximum capacity</string>
+    <string name="battery_maximum_capacity_summary" translatable="false">%1$d mAh (%2$d%%)</string>
+    <string name="battery_maximum_capacity_not_available" translatable="false">@string/battery_cycle_count_not_available</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -466,4 +466,8 @@
     <!-- Ambient wake toggles -->
     <string name="doze_gesture_ambient_title">Show Ambient</string>
     <string name="doze_gesture_ambient_summary">Show Ambient Display instead of fully waking the screen up</string>
+
+    <!-- Android debugging as root -->
+    <string name="adb_enable_root">Rooted debugging</string>
+    <string name="adb_enable_summary_root">Allow running Android debugging as root</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -439,4 +439,15 @@
     <string name="display_rotation_90_title">90 degrees</string>
     <string name="display_rotation_180_title">180 degrees</string>
     <string name="display_rotation_270_title">270 degrees</string>
+
+    <!-- Notification sound timeout -->
+    <string name="app_notification_sound_timeout_title">Minimum time between notification sounds</string>
+    <string name="app_notification_sound_timeout_summary_template">Allow sounds or vibration no more than once every <xliff:g id="duration">%1$s</xliff:g></string>
+    <string name="app_notification_sound_timeout_value_none">No restriction</string>
+    <string name="app_notification_sound_timeout_value_10_seconds">10 seconds</string>
+    <string name="app_notification_sound_timeout_value_30_seconds">30 seconds</string>
+    <string name="app_notification_sound_timeout_value_1_minute">1 minute</string>
+    <string name="app_notification_sound_timeout_value_5_minutes">5 minutes</string>
+    <string name="app_notification_sound_timeout_value_15_minutes">10 minutes</string>
+    <string name="app_notification_sound_timeout_value_30_minutes">30 minutes</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -34,6 +34,9 @@
 
     <string name="radio_info_title">Radio info</string>
 
+    <!-- Refresh rate -->
+    <string name="low_power_refresh_rate_title_custom">Low power refresh rate</string>
+
     <!-- Message shown in fingerprint enrollment dialog to locate the sensor -->
     <string name="fingerprint_enroll_find_sensor_message_front" product="tablet">Locate the fingerprint sensor on the front of your tablet.</string>
     <string name="fingerprint_enroll_find_sensor_message_front" product="device">Locate the fingerprint sensor on the front of your device.</string>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -484,4 +484,7 @@
     <string name="max_call_volume_title">Calls</string>
     <string name="max_alarm_volume_title">Alarms</string>
     <string name="steps_unit">steps</string>
+
+    <!-- Misc Haptics -->
+    <string name="misc_vibration_category_title">Misc Haptics</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -35,14 +35,30 @@
     <string name="radio_info_title">Radio info</string>
 
     <!-- Message shown in fingerprint enrollment dialog to locate the sensor -->
-    <string name="fingerprint_enroll_find_sensor_message_front">Locate the fingerprint sensor on the front of your device.</string>
-    <string name="fingerprint_enroll_find_sensor_message_rear">Locate the fingerprint sensor on the back of your device.</string>
-    <string name="fingerprint_enroll_find_sensor_message_side">Locate the fingerprint sensor on the side of your device.</string>
+    <string name="fingerprint_enroll_find_sensor_message_front" product="tablet">Locate the fingerprint sensor on the front of your tablet.</string>
+    <string name="fingerprint_enroll_find_sensor_message_front" product="device">Locate the fingerprint sensor on the front of your device.</string>
+    <string name="fingerprint_enroll_find_sensor_message_front" product="default">Locate the fingerprint sensor on the front of your phone.</string>
+    <string name="fingerprint_enroll_find_sensor_message_rear" product="tablet">Locate the fingerprint sensor on the back of your tablet.</string>
+    <string name="fingerprint_enroll_find_sensor_message_rear" product="device">Locate the fingerprint sensor on the back of your device.</string>
+    <string name="fingerprint_enroll_find_sensor_message_rear" product="default">Locate the fingerprint sensor on the back of your phone.</string>
+    <string name="fingerprint_enroll_find_sensor_message_side" product="tablet">Locate the fingerprint sensor on the side of your tablet.</string>
+    <string name="fingerprint_enroll_find_sensor_message_side" product="device">Locate the fingerprint sensor on the side of your device.</string>
+    <string name="fingerprint_enroll_find_sensor_message_side" product="default">Locate the fingerprint sensor on the side of your phone.</string>
 
     <!-- Message shown when user touches the icon on the screen, instead of the real fingerprint sensor -->
-    <string name="fingerprint_enroll_touch_dialog_message_front">Touch the sensor on the front of your device.</string>
-    <string name="fingerprint_enroll_touch_dialog_message_rear">Touch the sensor on the back of your device.</string>
-    <string name="fingerprint_enroll_touch_dialog_message_side">Touch the sensor on the side of your device.</string>
+    <string name="fingerprint_enroll_touch_dialog_message_front" product="tablet">Touch the sensor on the front of your tablet.</string>
+    <string name="fingerprint_enroll_touch_dialog_message_front" product="device">Touch the sensor on the front of your device.</string>
+    <string name="fingerprint_enroll_touch_dialog_message_front" product="default">Touch the sensor on the front of your phone.</string>
+    <string name="fingerprint_enroll_touch_dialog_message_rear" product="tablet">Touch the sensor on the back of your tablet.</string>
+    <string name="fingerprint_enroll_touch_dialog_message_rear" product="device">Touch the sensor on the back of your device.</string>
+    <string name="fingerprint_enroll_touch_dialog_message_rear" product="default">Touch the sensor on the back of your phone.</string>
+    <string name="fingerprint_enroll_touch_dialog_message_side" product="tablet">Touch the sensor on the side of your tablet.</string>
+    <string name="fingerprint_enroll_touch_dialog_message_side" product="device">Touch the sensor on the side of your device.</string>
+    <string name="fingerprint_enroll_touch_dialog_message_side" product="default">Touch the sensor on the side of your phone.</string>
+
+    <!-- Description for require screen on to auth toggle shown in fingerprint enrollment dialog once enrollment is completed.
+         Only for devices that support checking proximity prior to allowing fingerprint unlock. -->
+    <string name="security_settings_require_screen_on_to_auth_with_proximity_description">Touch the sensor to unlock, even when the screen is off. Proximity sensor prevents accidental unlocking.</string>
 
     <!-- Warning message for the sd card setup -->
     <string name="storage_warning_internal">Warning: This option may not work properly or lead to data loss and is therefore not recommended!</string>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -471,4 +471,9 @@
     <!-- Android debugging as root -->
     <string name="adb_enable_root">Rooted debugging</string>
     <string name="adb_enable_summary_root">Allow running Android debugging as root</string>
+
+    <!-- Display settings screen, increased touch polling rate settings title -->
+    <string name="touch_polling_title">High touch polling rate</string>
+    <!-- Display settings screen, increased touch polling rate settings summary -->
+    <string name="touch_polling_summary">Increase touchscreen polling rate to decrease latency</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -409,4 +409,8 @@
     <string name="notification_battery_charge_level_seek_bar">Battery level</string>
     <string name="notification_battery_charge_level_ringtone">Ringtone</string>
     <string name="notification_battery_charge_level_silent">Silent</string>
+
+    <!-- Proximity wake -->
+    <string name="proximity_wake_title">Prevent accidental wake-up</string>
+    <string name="proximity_wake_summary">Check the proximity sensor prior to waking up screen</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -476,4 +476,12 @@
     <string name="touch_polling_title">High touch polling rate</string>
     <!-- Display settings screen, increased touch polling rate settings summary -->
     <string name="touch_polling_summary">Increase touchscreen polling rate to decrease latency</string>
+
+    <!-- Volume Steps -->
+    <string name="volume_steps_title">Volume Steps</string>
+    <string name="volume_steps_summary">Control the granularity of each stream</string>
+    <string name="max_music_volume_title">Media</string>
+    <string name="max_call_volume_title">Calls</string>
+    <string name="max_alarm_volume_title">Alarms</string>
+    <string name="steps_unit">steps</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -401,4 +401,12 @@
     <string name="prevent_ringing_option_cycle">Cycle through modes</string>
     <string name="prevent_ringing_option_cycle_summary">On (cycle through modes)</string>
     <string name="prevent_ringing_option_normal">Normal</string>
+
+    <!-- Battery charge warning -->
+    <string name="notification_battery_charge_level_main_switch_title">Use Battery charge warning</string>
+    <string name="notification_battery_charge_level_title">Battery charge warning</string>
+    <string name="notification_battery_charge_level_summary">Play a sound when the battery as reach a level when charging</string>
+    <string name="notification_battery_charge_level_seek_bar">Battery level</string>
+    <string name="notification_battery_charge_level_ringtone">Ringtone</string>
+    <string name="notification_battery_charge_level_silent">Silent</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -425,4 +425,7 @@
 
     <!-- NFC sounds -->
     <string name="nfc_sounds_title">NFC sounds</string>
+
+    <!-- Floating rotation button -->
+    <string name="enable_floating_rotation_button_title">Use floating rotate button</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -224,6 +224,10 @@
     <!-- Quad9 DNS hostname -->
     <string name="private_dns_hostname_quad9" translatable="false">dns.quad9.net</string>
 
+     <!-- FastCharge feature -->
+     <string name="fast_charging_title">Fast charging</string>
+     <string name="fast_charging_summary">Disable to reduce the heat produced by the device while charging or to extend the lifespan of the battery</string>
+
     <!-- Screenshot shutter -->
     <string name="screenshot_shutter_sound_title">Screenshot sound</string>
 

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -422,4 +422,7 @@
 
     <!-- Screen resolution -->
     <string name="custom_screen_resolution_title">Custom screen resolution</string>
+
+    <!-- NFC sounds -->
+    <string name="nfc_sounds_title">NFC sounds</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -497,4 +497,45 @@
     <!-- Scroll fling haptic feedback -->
     <string name="scroll_fling_haptic_feedback_title">Vibrate on scroll flings</string>
     <string name="scroll_fling_haptic_feedback_summary">Vibrate on reaching edges when scrolling with fling gesture</string>
+
+    <!-- Custom actions -->
+    <string name="action_nothing">No action</string>
+    <string name="action_menu">Menu</string>
+    <string name="action_app_switch">Recents</string>
+    <string name="action_voice_search">Voice search</string>
+    <string name="action_launch_camera">Camera</string>
+    <string name="action_last_app">Last app</string>
+    <string name="action_splitscreen">Split screen</string>
+    <string name="action_flashlight">Flashlight</string>
+    <string name="action_clear_notifications">Clear notifications</string>
+    <string name="action_volume_panel">Volume panel</string>
+    <string name="action_screen_off">Screen off</string>
+    <string name="action_notifications">Notifications</string>
+    <string name="action_power_menu">Power menu</string>
+    <string name="action_screenshot">Screenshot</string>
+    <string name="action_qs_panel">QS panel</string>
+    <string name="action_app_action">Application</string>
+    <string name="action_ringer_modes">Ringer modes</string>
+    <string name="kill_app">Kill foreground app</string>
+    <string name="recent_app_toggle">Switch recent app</string>
+    <string name="show_powermenu">Show Power menu</string>
+    <string name="partial_screenshot">Partial screenshot</string>
+
+    <!-- Long swipe gestures -->
+    <string name="navbar_gesture_tweaks_pref_title">Advanced gestures options</string>
+    <string name="navbar_gesture_tweaks_pref_summary">Customize gestures and set custom actions</string>
+    <string name="navbar_gesture_tweaks_cat_title">Advanced</string>
+    <string name="swipe_app_select_summary">Select an app to launch with the squeeze action</string>
+    <string name="long_back_swipe_timeout_title">Long swipe action timeout</string>
+    <string name="left_swipe_actions_title">Long left swipe action</string>
+    <string name="left_swipe_app_action_title">Select long left swipe app</string>
+    <string name="right_swipe_actions_title">Long right swipe action</string>
+    <string name="right_swipe_app_action_title">Select long right swipe app</string>
+    <string name="left_vertical_swipe_actions_title">Vertical left L-swipe action</string>
+    <string name="left_vertical_swipe_app_action_title">Select vertical left swipe app</string>
+    <string name="right_vertical_swipe_actions_title">Vertical right L-swipe action</string>
+    <string name="right_vertical_swipe_app_action_title">Select vertical right swipe app</string>
+    <string name="gesture_nav_tweaks_footer_info">To choose a specific app activity for the action, long press on any app in the apps picker.\n\nIf launcher is showing, do the swipe at the very bottom area of the screen to trigger the action.</string>
+    <string name="back_swipe_extended_title">Extended swipe action</string>
+    <string name="back_swipe_extended_summary">Trigger action on wider swipe (more than half of display size), or a L swipe (vertically longer enough)</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -413,4 +413,10 @@
     <!-- Proximity wake -->
     <string name="proximity_wake_title">Prevent accidental wake-up</string>
     <string name="proximity_wake_summary">Check the proximity sensor prior to waking up screen</string>
+
+    <!-- DC Dimming -->
+    <string name="dc_dimming_title">DC Dimming</string>
+    <string name="dc_dimming_info">Reduces eye strain in low light conditions by minimizing screen flicker. May result in reduced image quality and poor color production, or higher power consumption.</string>
+    <string name="dc_dimming_main_switch_title">Use DC Dimming</string>
+    <string name="keywords_display_dc_dimming">dc dimming, anti, flicker, eye, strain</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -662,4 +662,14 @@
     <string name="battery_maximum_capacity">Maximum capacity</string>
     <string name="battery_maximum_capacity_summary" translatable="false">%1$d mAh (%2$d%%)</string>
     <string name="battery_maximum_capacity_not_available" translatable="false">@string/battery_cycle_count_not_available</string>
+
+    <!-- Display settings screen, peak refresh rate settings summary [CHAR LIMIT=NONE] -->
+    <string name="refresh_rate_title">Refresh rate</string>
+    <string name="refresh_rate_summary_vrr_off">%d Hz</string> 
+    <string name="refresh_rate_summary_vrr_on">%d Hz (Adaptive)</string>
+    <string name="refresh_rate_vrr_title">Adaptive refresh rate</string> 
+    <string name="refresh_rate_vrr_summary">Automatically lower the refresh rate when the display is idle, to save power. May cause flickering or color shift on certain displays</string> 
+    <string name="refresh_rate_footer">A higher refresh rate makes the display smoother, but increases power consumption</string>
+    <string name="keywords_refresh_rate">refresh, rate, smooth, peak, 60hz, 90hz, 120hz, 144hz, 165hz</string>
+    <string name="peak_refresh_rate_summary_custom">Automatically raises the refresh rate from 60 to %1$d Hz for some content. Increases battery usage.</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -493,4 +493,8 @@
     <string name="incall_vibrate_connect_title">Vibrate on connect</string>
     <string name="incall_vibrate_call_wait_title">Vibrate on call waiting</string>
     <string name="incall_vibrate_disconnect_title">Vibrate on disconnect</string>
+
+    <!-- Scroll fling haptic feedback -->
+    <string name="scroll_fling_haptic_feedback_title">Vibrate on scroll flings</string>
+    <string name="scroll_fling_haptic_feedback_summary">Vibrate on reaching edges when scrolling with fling gesture</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -538,4 +538,7 @@
     <string name="gesture_nav_tweaks_footer_info">To choose a specific app activity for the action, long press on any app in the apps picker.\n\nIf launcher is showing, do the swipe at the very bottom area of the screen to trigger the action.</string>
     <string name="back_swipe_extended_title">Extended swipe action</string>
     <string name="back_swipe_extended_summary">Trigger action on wider swipe (more than half of display size), or a L swipe (vertically longer enough)</string>
+
+    <!-- Auto pin confirm -->
+    <string name="lock_screen_auto_pin_confirm_summary_custom">Unlock automatically if you input a correct PIN. This is slightly less secure than tapping Enter to confirm.</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -541,4 +541,72 @@
 
     <!-- Auto pin confirm -->
     <string name="lock_screen_auto_pin_confirm_summary_custom">Unlock automatically if you input a correct PIN. This is slightly less secure than tapping Enter to confirm.</string>
+
+    <!-- Notification channels -->
+    <string name="channel_light_settings_id" translatable="false">light_settings</string>
+    <string name="channel_light_settings_name">Light settings preview</string>
+
+    <!-- Notification light dialogs -->
+    <string name="edit_light_settings">Edit light settings</string>
+    <string name="pulse_speed_title">Pulse length and speed</string>
+    <string name="default_time">Normal</string>
+    <string name="custom_time">Custom</string>
+    <string name="dialog_delete_title">Delete</string>
+    <string name="dialog_delete_message">Remove selected item?</string>
+    <string name="brightness">Brightness level</string>
+    <string name="choose_app">Choose app</string>
+
+    <!-- Values for the notification light pulse spinners -->
+    <string name="pulse_length_always_on">Always on</string>
+    <string name="pulse_length_very_short">Very short</string>
+    <string name="pulse_length_short">Short</string>
+    <string name="pulse_length_normal">Normal</string>
+    <string name="pulse_length_long">Long</string>
+    <string name="pulse_length_very_long">Very long</string>
+    <string name="pulse_speed_very_fast">Very fast</string>
+    <string name="pulse_speed_fast">Fast</string>
+    <string name="pulse_speed_normal">Normal</string>
+    <string name="pulse_speed_slow">Slow</string>
+    <string name="pulse_speed_very_slow">Very slow</string>
+
+    <!-- Common light settings strings -->
+    <string name="light_brightness_title">Brightness levels</string>
+    <string name="light_brightness_normal">Normal</string>
+    <string name="light_brightness_zen">Do Not Disturb</string>
+
+    <!-- Battery light settings -->
+    <string name="battery_light_title">Battery light</string>
+    <string name="battery_light_enable_title">Enable battery light</string>
+    <string name="battery_low_pulse_title">Pulse if battery low</string>
+    <string name="battery_light_full_charge_disabled_title">Turn off when fully charged</string>
+    <string name="battery_light_list_title">Colors</string>
+    <string name="battery_light_low_color_title">Battery low</string>
+    <string name="battery_light_medium_color_title">Charging</string>
+    <string name="battery_light_full_color_title">Fully charged</string>
+    <string name="battery_light_brightness_normal" translatable="false">@string/light_brightness_normal</string>
+    <string name="battery_light_brightness_zen" translatable="false">@string/light_brightness_zen</string>
+
+    <!-- Lights settings screen, notification light settings -->
+    <string name="notification_light_title">Notification light</string>
+    <string name="notification_light_enable_title">Enable notification light</string>
+    <string name="notification_light_general_title">General</string>
+    <string name="notification_light_advanced_title">Advanced</string>
+    <string name="notification_light_applist_title">Apps</string>
+    <string name="notification_light_phonelist_title">Phone</string>
+    <string name="notification_light_use_custom">Use custom values</string>
+    <string name="notification_light_default_value">Default</string>
+    <string name="notification_light_missed_call_title">Missed call</string>
+    <string name="notification_light_voicemail_title">Voicemail</string>
+    <string name="notification_light_brightness_normal" translatable="false">@string/light_brightness_normal</string>
+    <string name="notification_light_brightness_zen" translatable="false">@string/light_brightness_zen</string>
+    <string name="notification_light_screen_on">Lights with screen on</string>
+    <string name="notification_light_zen_mode">Lights in Do Not Disturb mode</string>
+    <string name="keywords_lights_brightness_level">dim leds brightness</string>
+    <string name="notification_light_automagic">Choose colors automatically</string>
+    <string name="notification_light_automagic_summary">Choosing colors automatically</string>
+
+    <!-- Lights settings, LED notification -->
+    <string name="led_notification_title">Light settings</string>
+    <string name="led_notification_text">LED light enabled by settings</string>
+    <string name="notification_light_add_apps_empty_summary">To add per app control, activate \'%1$s\' and press \'Add\'</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -450,4 +450,7 @@
     <string name="app_notification_sound_timeout_value_5_minutes">5 minutes</string>
     <string name="app_notification_sound_timeout_value_15_minutes">10 minutes</string>
     <string name="app_notification_sound_timeout_value_30_minutes">30 minutes</string>
+
+    <!-- Running services - Background processes tab -->
+    <string name="background_processes_settings_title">Background processes</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -576,6 +576,7 @@
 
     <!-- Battery light settings -->
     <string name="battery_light_title">Battery light</string>
+    <string name="battery_light_summary">Customize battery charging light behavior</string>
     <string name="battery_light_enable_title">Enable battery light</string>
     <string name="battery_low_pulse_title">Pulse if battery low</string>
     <string name="battery_light_full_charge_disabled_title">Turn off when fully charged</string>
@@ -589,6 +590,7 @@
 
     <!-- Lights settings screen, notification light settings -->
     <string name="notification_light_title">Notification light</string>
+    <string name="notification_light_summary">Customize Notification light behavior</string>
     <string name="notification_light_enable_title">Enable notification light</string>
     <string name="notification_light_general_title">General</string>
     <string name="notification_light_advanced_title">Advanced</string>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -428,4 +428,15 @@
 
     <!-- Floating rotation button -->
     <string name="enable_floating_rotation_button_title">Use floating rotate button</string>
+
+    <!-- Display - Rotation -->
+    <string name="display_rotation_title">Rotation settings</string>
+    <string name="display_rotation_enabled">Auto-rotation is enabled</string>
+    <string name="display_rotation_disabled">Auto-rotation is disabled</string>
+    <string name="display_rotation_unit">degrees</string>
+    <string name="display_rotation_category_title">Rotation modes</string>
+    <string name="display_rotation_0_title">0 degrees</string>
+    <string name="display_rotation_90_title">90 degrees</string>
+    <string name="display_rotation_180_title">180 degrees</string>
+    <string name="display_rotation_270_title">270 degrees</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -520,6 +520,7 @@
     <string name="recent_app_toggle">Switch recent app</string>
     <string name="show_powermenu">Show Power menu</string>
     <string name="partial_screenshot">Partial screenshot</string>
+    <string name="action_forward">Go forward</string>
 
     <!-- Long swipe gestures -->
     <string name="navbar_gesture_tweaks_pref_title">Advanced gestures options</string>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -419,4 +419,7 @@
     <string name="dc_dimming_info">Reduces eye strain in low light conditions by minimizing screen flicker. May result in reduced image quality and poor color production, or higher power consumption.</string>
     <string name="dc_dimming_main_switch_title">Use DC Dimming</string>
     <string name="keywords_display_dc_dimming">dc dimming, anti, flicker, eye, strain</string>
+
+    <!-- Screen resolution -->
+    <string name="custom_screen_resolution_title">Custom screen resolution</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -487,4 +487,10 @@
 
     <!-- Misc Haptics -->
     <string name="misc_vibration_category_title">Misc Haptics</string>
+
+    <!-- Incall vibrate options -->
+    <string name="incall_vibration_category">In-call vibration options</string>
+    <string name="incall_vibrate_connect_title">Vibrate on connect</string>
+    <string name="incall_vibrate_call_wait_title">Vibrate on call waiting</string>
+    <string name="incall_vibrate_disconnect_title">Vibrate on disconnect</string>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -526,7 +526,6 @@
     <string name="navbar_gesture_tweaks_pref_summary">Customize gestures and set custom actions</string>
     <string name="navbar_gesture_tweaks_cat_title">Advanced</string>
     <string name="swipe_app_select_summary">Select an app to launch with the squeeze action</string>
-    <string name="long_back_swipe_timeout_title">Long swipe action timeout</string>
     <string name="left_swipe_actions_title">Long left swipe action</string>
     <string name="left_swipe_app_action_title">Select long left swipe app</string>
     <string name="right_swipe_actions_title">Long right swipe action</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -7480,6 +7480,12 @@
     <!-- Sound: Title for the option defining the phone ringtone. [CHAR LIMIT=30] -->
     <string name="ringtone_title">Phone ringtone</string>
 
+    <!-- Sound: Title for the option defining the phone ringtone for slot1 on Muilti SIM device. [CHAR LIMIT=50] -->
+    <string name="ringtone1_title">Phone ringtone - SIM 1</string>
+
+    <!-- Sound: Title for the option defining the phone ringtone for slot2 on Muilti SIM device. [CHAR LIMIT=50] -->
+    <string name="ringtone2_title">Phone ringtone - SIM 2</string>
+
     <!-- Sound: Title for the option defining the default notification sound. [CHAR LIMIT=30] -->
     <string name="notification_ringtone_title">Default notification sound</string>
 

--- a/res/xml/accessibility_vibration_intensity_settings.xml
+++ b/res/xml/accessibility_vibration_intensity_settings.xml
@@ -85,4 +85,11 @@
 
     </PreferenceCategory>
 
+    <!-- Misc vibration options -->
+    <PreferenceCategory
+        android:key="misc_vibration_category"
+        android:title="@string/misc_vibration_category_title" >
+
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/res/xml/accessibility_vibration_intensity_settings.xml
+++ b/res/xml/accessibility_vibration_intensity_settings.xml
@@ -132,6 +132,13 @@
             android:title="@string/volume_slider_haptic_feedback_title"
             android:defaultValue="false" />
 
+        <!-- Scroll fling haptic feedback -->
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="scroll_fling_haptic_feedback"
+            android:title="@string/scroll_fling_haptic_feedback_title"
+            android:dependency="vibration_intensity_preference_touch"
+            android:defaultValue="false" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/res/xml/accessibility_vibration_intensity_settings.xml
+++ b/res/xml/accessibility_vibration_intensity_settings.xml
@@ -111,12 +111,19 @@
     <!-- Misc vibration options -->
     <PreferenceCategory
         android:key="misc_vibration_category"
-        android:title="@string/misc_vibration_category_title" >
+        android:title="@string/misc_vibration_category_title"
+        app:controller="com.android.settings.sound.CustomHapticPreferenceController">
 
         <!-- QS Bightness slider haptic feedback -->
         <com.evolution.settings.preference.SystemSettingSwitchPreference
             android:key="qs_brightness_slider_haptic"
             android:title="@string/qs_brightness_slider_haptic_feedback_title"
+            android:defaultValue="false" />
+
+        <!-- Volume slider haptic -->
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="volume_slider_haptic"
+            android:title="@string/volume_slider_haptic_feedback_title"
             android:defaultValue="false" />
 
     </PreferenceCategory>

--- a/res/xml/accessibility_vibration_intensity_settings.xml
+++ b/res/xml/accessibility_vibration_intensity_settings.xml
@@ -120,6 +120,12 @@
             android:title="@string/qs_brightness_slider_haptic_feedback_title"
             android:defaultValue="false" />
 
+        <!-- QS Tiles haptic -->
+        <com.evolution.settings.preference.SecureSettingSwitchPreference
+            android:key="quick_settings_vibrate"
+            android:title="@string/qs_tiles_haptic_feedback_title"
+            android:defaultValue="false" />
+
         <!-- Volume slider haptic -->
         <com.evolution.settings.preference.SystemSettingSwitchPreference
             android:key="volume_slider_haptic"

--- a/res/xml/accessibility_vibration_intensity_settings.xml
+++ b/res/xml/accessibility_vibration_intensity_settings.xml
@@ -113,6 +113,12 @@
         android:key="misc_vibration_category"
         android:title="@string/misc_vibration_category_title" >
 
+        <!-- QS Bightness slider haptic feedback -->
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="qs_brightness_slider_haptic"
+            android:title="@string/qs_brightness_slider_haptic_feedback_title"
+            android:defaultValue="false" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/res/xml/accessibility_vibration_intensity_settings.xml
+++ b/res/xml/accessibility_vibration_intensity_settings.xml
@@ -85,6 +85,29 @@
 
     </PreferenceCategory>
 
+    <!-- Incall vibration options -->
+    <PreferenceCategory
+        android:key="accessibility_incall_vibration_category"
+        android:title="@string/incall_vibration_category"
+        app:controller="com.android.settings.sound.IncallFeedbackPreferenceController">
+
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="vibrate_on_connect"
+            android:title="@string/incall_vibrate_connect_title"
+            android:defaultValue="true" />
+
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="vibrate_on_callwaiting"
+            android:title="@string/incall_vibrate_call_wait_title"
+            android:defaultValue="true" />
+
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="vibrate_on_disconnect"
+            android:title="@string/incall_vibrate_disconnect_title"
+            android:defaultValue="true" />
+
+    </PreferenceCategory>
+
     <!-- Misc vibration options -->
     <PreferenceCategory
         android:key="misc_vibration_category"

--- a/res/xml/accessibility_vibration_settings.xml
+++ b/res/xml/accessibility_vibration_settings.xml
@@ -85,4 +85,11 @@
 
     </PreferenceCategory>
 
+    <!-- Misc vibration options -->
+    <PreferenceCategory
+        android:key="misc_vibration_category"
+        android:title="@string/misc_vibration_category_title" >
+
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/res/xml/accessibility_vibration_settings.xml
+++ b/res/xml/accessibility_vibration_settings.xml
@@ -132,6 +132,13 @@
             android:title="@string/volume_slider_haptic_feedback_title"
             android:defaultValue="false" />
 
+        <!-- Scroll fling haptic feedback -->
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="scroll_fling_haptic_feedback"
+            android:title="@string/scroll_fling_haptic_feedback_title"
+            android:dependency="vibration_intensity_preference_touch"
+            android:defaultValue="false" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/res/xml/accessibility_vibration_settings.xml
+++ b/res/xml/accessibility_vibration_settings.xml
@@ -111,12 +111,19 @@
     <!-- Misc vibration options -->
     <PreferenceCategory
         android:key="misc_vibration_category"
-        android:title="@string/misc_vibration_category_title" >
+        android:title="@string/misc_vibration_category_title"
+        app:controller="com.android.settings.sound.CustomHapticPreferenceController">
 
         <!-- QS Bightness slider haptic feedback -->
         <com.evolution.settings.preference.SystemSettingSwitchPreference
             android:key="qs_brightness_slider_haptic"
             android:title="@string/qs_brightness_slider_haptic_feedback_title"
+            android:defaultValue="false" />
+
+        <!-- Volume slider haptic -->
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="volume_slider_haptic"
+            android:title="@string/volume_slider_haptic_feedback_title"
             android:defaultValue="false" />
 
     </PreferenceCategory>

--- a/res/xml/accessibility_vibration_settings.xml
+++ b/res/xml/accessibility_vibration_settings.xml
@@ -118,25 +118,28 @@
         <com.evolution.settings.preference.SystemSettingSwitchPreference
             android:key="qs_brightness_slider_haptic"
             android:title="@string/qs_brightness_slider_haptic_feedback_title"
+            android:dependency="vibration_preference_touch"
             android:defaultValue="false" />
 
         <!-- QS Tiles haptic -->
         <com.evolution.settings.preference.SecureSettingSwitchPreference
             android:key="quick_settings_vibrate"
             android:title="@string/qs_tiles_haptic_feedback_title"
+            android:dependency="vibration_preference_touch"
             android:defaultValue="false" />
 
         <!-- Volume slider haptic -->
         <com.evolution.settings.preference.SystemSettingSwitchPreference
             android:key="volume_slider_haptic"
             android:title="@string/volume_slider_haptic_feedback_title"
+            android:dependency="vibration_preference_touch"
             android:defaultValue="false" />
 
         <!-- Scroll fling haptic feedback -->
         <com.evolution.settings.preference.SystemSettingSwitchPreference
             android:key="scroll_fling_haptic_feedback"
             android:title="@string/scroll_fling_haptic_feedback_title"
-            android:dependency="vibration_intensity_preference_touch"
+            android:dependency="vibration_preference_touch"
             android:defaultValue="false" />
 
     </PreferenceCategory>

--- a/res/xml/accessibility_vibration_settings.xml
+++ b/res/xml/accessibility_vibration_settings.xml
@@ -120,6 +120,12 @@
             android:title="@string/qs_brightness_slider_haptic_feedback_title"
             android:defaultValue="false" />
 
+        <!-- QS Tiles haptic -->
+        <com.evolution.settings.preference.SecureSettingSwitchPreference
+            android:key="quick_settings_vibrate"
+            android:title="@string/qs_tiles_haptic_feedback_title"
+            android:defaultValue="false" />
+
         <!-- Volume slider haptic -->
         <com.evolution.settings.preference.SystemSettingSwitchPreference
             android:key="volume_slider_haptic"

--- a/res/xml/accessibility_vibration_settings.xml
+++ b/res/xml/accessibility_vibration_settings.xml
@@ -113,6 +113,12 @@
         android:key="misc_vibration_category"
         android:title="@string/misc_vibration_category_title" >
 
+        <!-- QS Bightness slider haptic feedback -->
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="qs_brightness_slider_haptic"
+            android:title="@string/qs_brightness_slider_haptic_feedback_title"
+            android:defaultValue="false" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/res/xml/accessibility_vibration_settings.xml
+++ b/res/xml/accessibility_vibration_settings.xml
@@ -85,6 +85,29 @@
 
     </PreferenceCategory>
 
+    <!-- Incall vibration options -->
+    <PreferenceCategory
+        android:key="accessibility_incall_vibration_category"
+        android:title="@string/incall_vibration_category"
+        app:controller="com.android.settings.sound.IncallFeedbackPreferenceController">
+
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="vibrate_on_connect"
+            android:title="@string/incall_vibrate_connect_title"
+            android:defaultValue="true" />
+
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="vibrate_on_callwaiting"
+            android:title="@string/incall_vibrate_call_wait_title"
+            android:defaultValue="true" />
+
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="vibrate_on_disconnect"
+            android:title="@string/incall_vibrate_disconnect_title"
+            android:defaultValue="true" />
+
+    </PreferenceCategory>
+
     <!-- Misc vibration options -->
     <PreferenceCategory
         android:key="misc_vibration_category"

--- a/res/xml/app_notification_settings.xml
+++ b/res/xml/app_notification_settings.xml
@@ -86,6 +86,20 @@
         settings:allowDividerAbove="true"
         settings:allowDividerBelow="false" />
 
+    <com.android.settings.RestrictedListPreference
+        android:key="sound_timeout"
+        android:title="@string/app_notification_sound_timeout_title"
+        android:entries="@array/app_notification_sound_timeout_entries"
+        android:entryValues="@array/app_notification_sound_timeout_values"
+        android:order="1003"
+        android:persistent="false" />
+
+        <Preference
+            android:key="app_link"
+            android:order="1003"
+            android:icon="@drawable/ic_settings_24dp"
+            android:title="@string/app_settings_link" />
+
     <!-- Show badge -->
     <com.android.settingslib.RestrictedSwitchPreference
         android:key="badge"

--- a/res/xml/auto_rotate_settings.xml
+++ b/res/xml/auto_rotate_settings.xml
@@ -60,6 +60,11 @@
         android:title="@string/auto_rotate_switch_face_based"
         settings:controller="com.android.settings.display.SmartAutoRotateController" />
 
+    <SwitchPreference
+        android:key="lockscreen_rotation"
+        android:title="@string/display_lockscreen_rotation_title"
+        android:dependency="auto_rotate_switch" />
+
     <PreferenceCategory
         android:key="display_rotation_category"
         android:title="@string/display_rotation_category_title">

--- a/res/xml/auto_rotate_settings.xml
+++ b/res/xml/auto_rotate_settings.xml
@@ -60,6 +60,31 @@
         android:title="@string/auto_rotate_switch_face_based"
         settings:controller="com.android.settings.display.SmartAutoRotateController" />
 
+    <PreferenceCategory
+        android:key="display_rotation_category"
+        android:title="@string/display_rotation_category_title">
+
+        <SwitchPreference
+            android:key="display_rotation_0"
+            android:title="@string/display_rotation_0_title"
+            android:dependency="auto_rotate_switch" />
+
+        <SwitchPreference
+            android:key="display_rotation_90"
+            android:title="@string/display_rotation_90_title"
+            android:dependency="auto_rotate_switch" />
+
+        <SwitchPreference
+            android:key="display_rotation_180"
+            android:title="@string/display_rotation_180_title"
+            android:dependency="auto_rotate_switch" />
+
+        <SwitchPreference
+            android:key="display_rotation_270"
+            android:title="@string/display_rotation_270_title"
+            android:dependency="auto_rotate_switch" />
+    </PreferenceCategory>
+
     <com.android.settingslib.widget.FooterPreference
         android:key="auto_rotate_footer_preference"
         android:title="@string/smart_rotate_text_headline"

--- a/res/xml/auto_rotate_settings.xml
+++ b/res/xml/auto_rotate_settings.xml
@@ -33,6 +33,11 @@
         android:title="@string/auto_rotate_settings_primary_switch_title"
         settings:controller="com.android.settings.display.AutoRotatePreferenceController"/>
 
+    <com.evolution.settings.preference.SystemSettingSwitchPreference
+        android:key="enable_floating_rotation_button"
+        android:title="@string/enable_floating_rotation_button_title"
+        android:defaultValue="true" />
+
     <com.android.settingslib.widget.BannerMessagePreference
         android:key="face_rotate_permission"
         android:title="@string/adaptive_sleep_title_no_permission"

--- a/res/xml/battery_info.xml
+++ b/res/xml/battery_info.xml
@@ -22,6 +22,48 @@
     settings:keywords="@string/keywords_battery_info">
 
     <Preference
+        android:key="battery_info_technology"
+        android:title="@string/battery_technology"
+        android:summary="@string/summary_placeholder"
+        settings:controller="com.android.settings.deviceinfo.batteryinfo.BatteryTechnologyPreferenceController"
+        settings:enableCopying="true"/>
+
+    <Preference
+        android:key="battery_info_health"
+        android:title="@string/battery_health"
+        android:summary="@string/summary_placeholder"
+        settings:controller="com.android.settings.deviceinfo.batteryinfo.BatteryHealthPreferenceController"
+        settings:enableCopying="true"/>
+
+    <Preference
+        android:key="battery_info_temperature"
+        android:title="@string/battery_temperature"
+        android:summary="@string/summary_placeholder"
+        settings:controller="com.android.settings.deviceinfo.batteryinfo.BatteryTemperaturePreferenceController"
+        settings:enableCopying="true"/>
+
+    <Preference
+        android:key="battery_info_voltage"
+        android:title="@string/battery_voltage"
+        android:summary="@string/summary_placeholder"
+        settings:controller="com.android.settings.deviceinfo.batteryinfo.BatteryVoltagePreferenceController"
+        settings:enableCopying="true"/>
+
+    <Preference
+        android:key="battery_info_design_capacity"
+        android:title="@string/battery_design_capacity"
+        android:summary="@string/summary_placeholder"
+        settings:controller="com.android.settings.deviceinfo.batteryinfo.BatteryDesignCapacityPreferenceController"
+        settings:enableCopying="true"/>
+
+    <Preference
+        android:key="battery_info_maximum_capacity"
+        android:title="@string/battery_maximum_capacity"
+        android:summary="@string/summary_placeholder"
+        settings:controller="com.android.settings.deviceinfo.batteryinfo.BatteryMaximumCapacityPreferenceController"
+        settings:enableCopying="true"/>
+
+    <Preference
         android:key="battery_info_manufacture_date"
         android:title="@string/battery_manufacture_date"
         android:summary="@string/summary_placeholder"

--- a/res/xml/battery_light_settings.xml
+++ b/res/xml/battery_light_settings.xml
@@ -63,6 +63,11 @@
             android:title="@string/battery_light_full_color_title"
             android:persistent="false" />
 
+        <com.android.settings.evolution.notificationlight.ApplicationLightPreference
+            android:key="really_full_color"
+            android:title="@string/battery_light_really_full_color_title"
+            android:persistent="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/res/xml/battery_light_settings.xml
+++ b/res/xml/battery_light_settings.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2016 The CyanogenMod Project
+                   2017-2018,2021 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+        android:key="battery_lights"
+        android:title="@string/battery_light_title">
+
+    <com.evolution.settings.preference.SystemSettingMainSwitchPreference
+        android:key="battery_light_enabled"
+        android:title="@string/battery_light_enable_title"
+        android:defaultValue="@bool/def_battery_light_enabled" />
+
+    <PreferenceCategory
+        android:key="general_section"
+        android:title="@string/notification_light_general_title">
+
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="battery_light_pulse"
+            android:title="@string/battery_low_pulse_title"
+            android:defaultValue="@bool/def_battery_light_pulse"
+            android:dependency="battery_light_enabled" />
+
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="battery_light_full_charge_disabled"
+            android:title="@string/battery_light_full_charge_disabled_title"
+            android:defaultValue="@bool/def_battery_light_full_charge_disabled"
+            android:dependency="battery_light_enabled" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="colors_list"
+        android:title="@string/battery_light_list_title"
+        android:dependency="battery_light_enabled" >
+
+        <com.android.settings.evolution.notificationlight.ApplicationLightPreference
+            android:key="low_color"
+            android:title="@string/battery_light_low_color_title"
+            android:persistent="false" />
+
+        <com.android.settings.evolution.notificationlight.ApplicationLightPreference
+            android:key="medium_color"
+            android:title="@string/battery_light_medium_color_title"
+            android:persistent="false" />
+
+        <com.android.settings.evolution.notificationlight.ApplicationLightPreference
+            android:key="full_color"
+            android:title="@string/battery_light_full_color_title"
+            android:persistent="false" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="brightness_section"
+        android:title="@string/light_brightness_title"
+        android:dependency="battery_light_enabled" >
+
+        <com.android.settings.evolution.notificationlight.BatteryBrightnessPreference
+            android:key="battery_light_brightness_level"
+            android:title="@string/battery_light_brightness_normal"
+            android:dependency="battery_light_enabled" />
+
+        <com.android.settings.evolution.notificationlight.BatteryBrightnessZenPreference
+            android:key="battery_light_brightness_level_zen"
+            android:title="@string/battery_light_brightness_zen"
+            android:dependency="battery_light_enabled" />
+
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/res/xml/configure_notification_settings.xml
+++ b/res/xml/configure_notification_settings.xml
@@ -172,12 +172,14 @@
             android:title="@string/notification_badging_title"
             settings:controller="com.android.settings.notification.BadgingNotificationPreferenceController"/>
 
-        <!-- Pulse notification light, on devices that support it -->
-        <SwitchPreferenceCompat
-            android:key="notification_pulse"
+        <!-- Notification light, on devices that support it -->
+        <Preference
+            android:key="notification_lights"
             android:order="24"
-            android:title="@string/notification_pulse_title"
-            settings:controller="com.android.settings.notification.PulseNotificationPreferenceController"/>
+            android:title="@string/notification_light_title"
+            android:summary="@string/notification_light_summary"
+            android:fragment="com.android.settings.evolution.notificationlight.NotificationLightSettings"
+            settings:controller="com.android.settings.evolution.notificationlight.NotificationLightPreferenceController" />
 
         <SwitchPreferenceCompat
             android:key="notification_assistant"

--- a/res/xml/dc_dimming_settings.xml
+++ b/res/xml/dc_dimming_settings.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2020 Paranoid Android
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<PreferenceScreen
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:settings="http://schemas.android.com/apk/res-auto"
+        android:title="@string/dc_dimming_title"
+        android:key="dc_dimming_title"
+        settings:keywords="@string/keywords_display_dc_dimming">
+
+    <com.android.settingslib.widget.MainSwitchPreference
+        android:key="dc_dimming_activated"
+        android:title="@string/dc_dimming_main_switch_title" />
+
+    <com.android.settingslib.widget.BannerMessagePreference
+        android:key="dc_dimming_location_off"
+        android:title="@string/twilight_mode_location_off_dialog_message"
+        settings:controller="com.android.settings.display.TwilightLocationPreferenceController" />
+
+    <com.android.settingslib.widget.TopIntroPreference
+        android:key="dc_dimming_top_intro"
+        android:title="@string/dc_dimming_info"
+        settings:searchable="false"/>
+
+    <DropDownPreference
+        android:key="dc_dimming_auto_mode"
+        android:title="@string/dark_ui_auto_mode_title"
+        android:summary="%s" />
+
+</PreferenceScreen>

--- a/res/xml/development_settings.xml
+++ b/res/xml/development_settings.xml
@@ -154,7 +154,7 @@
             android:title="@string/enable_adb"
             android:summary="@string/enable_adb_summary" />
 
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:key="enable_adb_root"
             android:title="@string/adb_enable_root"
             android:summary="@string/adb_enable_summary_root"

--- a/res/xml/development_settings.xml
+++ b/res/xml/development_settings.xml
@@ -154,13 +154,6 @@
             android:title="@string/enable_adb"
             android:summary="@string/enable_adb_summary" />
 
-        <SwitchPreferenceCompat
-            android:key="enable_adb_root"
-            android:title="@string/adb_enable_root"
-            android:summary="@string/adb_enable_summary_root"
-            android:dependency="enable_adb"
-            android:persistent="false" />
-
         <Preference android:key="clear_adb_keys"
                     android:title="@string/clear_adb_keys" />
 
@@ -170,6 +163,12 @@
             android:title="@string/enable_adb_wireless"
             android:summary="@string/enable_adb_wireless_summary"
             settings:keywords="@string/keywords_adb_wireless" />
+
+        <SwitchPreferenceCompat
+            android:key="enable_adb_root"
+            android:title="@string/adb_enable_root"
+            android:summary="@string/adb_enable_summary_root"
+            android:persistent="false" />
 
         <SwitchPreferenceCompat
             android:key="adb_authorization_timeout"

--- a/res/xml/development_settings.xml
+++ b/res/xml/development_settings.xml
@@ -154,6 +154,13 @@
             android:title="@string/enable_adb"
             android:summary="@string/enable_adb_summary" />
 
+        <SwitchPreference
+            android:key="enable_adb_root"
+            android:title="@string/adb_enable_root"
+            android:summary="@string/adb_enable_summary_root"
+            android:dependency="enable_adb"
+            android:persistent="false" />
+
         <Preference android:key="clear_adb_keys"
                     android:title="@string/clear_adb_keys" />
 

--- a/res/xml/development_settings.xml
+++ b/res/xml/development_settings.xml
@@ -29,10 +29,10 @@
             android:summary="@string/summary_placeholder"
             android:fragment="com.android.settings.applications.ProcessStatsSummary" />
 
-        <com.android.settings.BugreportPreference
+        <!--<com.android.settings.BugreportPreference
             android:key="bugreport"
             android:title="@*android:string/bugreport_title"
-            android:dialogTitle="@*android:string/bugreport_title" />
+            android:dialogTitle="@*android:string/bugreport_title" />-->
 
         <Preference
             android:key="bug_report_handler"
@@ -174,10 +174,10 @@
             android:title="@string/enable_terminal_title"
             android:summary="@string/enable_terminal_summary" />
 
-        <SwitchPreferenceCompat
+        <!--<SwitchPreferenceCompat
             android:key="bugreport_in_power"
             android:title="@string/bugreport_in_power"
-            android:summary="@string/bugreport_in_power_summary" />
+            android:summary="@string/bugreport_in_power_summary" />-->
 
         <SwitchPreferenceCompat
             android:key="enable_verbose_vendor_logging"

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -35,6 +35,7 @@
             android:key="auto_brightness_entry"
             android:title="@string/auto_brightness_title"
             android:fragment="com.android.settings.display.AutoBrightnessSettings"
+            settings:userRestriction="no_config_brightness"
             settings:controller="com.android.settings.display.AutoBrightnessPreferenceController"/>
 
         <com.android.settingslib.PrimarySwitchPreference

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -169,11 +169,21 @@
             android:summary="@string/display_white_balance_summary"
             settings:controller="com.android.settings.display.DisplayWhiteBalancePreferenceController"/>
 
+        <Preference
+            android:key="refresh_rate"
+            android:title="@string/refresh_rate_title"
+            android:summary="@string/summary_placeholder"
+            android:fragment="com.android.settings.display.RefreshRateSettings"
+            settings:keywords="@string/keywords_refresh_rate"
+            settings:controller="com.android.settings.display.RefreshRatePreferenceController"/>
+
+        <!--
         <SwitchPreferenceCompat
             android:key="peak_refresh_rate"
             android:title="@string/peak_refresh_rate_title"
             android:summary="@string/peak_refresh_rate_summary"
             settings:controller="com.android.settings.display.PeakRefreshRatePreferenceController"/>
+        -->
 
         <SwitchPreferenceCompat
             android:key="show_operator_name"

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -154,6 +154,14 @@
             settings:widgetLayout="@null"
             settings:keywords="@string/keywords_display_dc_dimming"/>
 
+        <!-- Smart Pixels -->
+        <Preference
+            android:key="smart_pixels"
+            android:title="@string/smart_pixels_title" 
+            android:summary="@string/smart_pixels_summary"
+            android:fragment="com.android.settings.display.SmartPixels"
+            settings:requiresConfig="@*android:bool/config_supportSmartPixels" />
+
         <SwitchPreferenceCompat
             android:key="display_white_balance"
             android:title="@string/display_white_balance_title"

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -126,26 +126,12 @@
     <PreferenceCategory
         android:title="@string/category_name_display_controls">
 
-        <!--
-            Standard auto-rotation preference that will be shown when device state based
-            auto-rotation settings are NOT available.
-          -->
-        <SwitchPreferenceCompat
+        <com.android.settingslib.PrimarySwitchPreference
+            android:fragment="com.android.settings.display.SmartAutoRotatePreferenceFragment"
             android:key="auto_rotate"
             android:title="@string/accelerometer_title"
-            settings:keywords="@string/keywords_auto_rotate"
-            settings:controller="com.android.settings.display.AutoRotatePreferenceController"/>
-
-        <!--
-            Auto-rotation preference that will be shown when device state based auto-rotation
-            settings are available.
-          -->
-        <Preference
-            android:key="device_state_auto_rotate"
-            android:title="@string/accelerometer_title"
-            android:fragment="com.android.settings.display.DeviceStateAutoRotateDetailsFragment"
-            settings:keywords="@string/keywords_auto_rotate"
-            settings:controller="com.android.settings.display.DeviceStateAutoRotateOverviewController"/>
+            settings:controller="com.android.settings.display.SmartAutoRotatePreferenceController"
+            settings:keywords="@string/keywords_auto_rotate" />
 
         <Preference
             android:key="screen_resolution"

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -185,6 +185,12 @@
             settings:controller="com.android.settings.display.PeakRefreshRatePreferenceController"/>
         -->
 
+        <ListPreference
+            android:key="low_power_refresh_rate"
+            android:title="@string/low_power_refresh_rate_title_custom"
+            android:summary="@string/summary_placeholder"
+            settings:controller="com.android.settings.display.LowPowerRefreshRatePreferenceController" />
+
         <SwitchPreferenceCompat
             android:key="show_operator_name"
             android:title="@string/show_operator_name_title"

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -235,7 +235,7 @@
             android:defaultValue="false"
             settings:controller="com.android.settings.custom.touch.HighTouchPollingRateSettingsPreferenceController" />
 
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:key="touch_polling"
             android:title="@string/touch_polling_title"
             android:summary="@string/touch_polling_summary"

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -154,6 +154,12 @@
             settings:keywords="@string/keywords_screen_resolution"
             settings:controller="com.android.settings.display.ScreenResolutionController"/>
 
+        <ListPreference
+            android:key="custom_screen_resolution"
+            android:title="@string/custom_screen_resolution_title"
+            android:summary="@string/summary_placeholder"
+            settings:controller="com.android.settings.display.CustomScreenResolutionController"/>
+
         <com.android.settings.display.DcDimmingPreference
             android:key="dc_dimming"
             android:title="@string/dc_dimming_title"

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -216,6 +216,12 @@
             android:defaultValue="false"
             settings:controller="com.android.settings.custom.touch.HighTouchPollingRateSettingsPreferenceController" />
 
+        <SwitchPreference
+            android:key="touch_polling"
+            android:title="@string/touch_polling_title"
+            android:summary="@string/touch_polling_summary"
+            settings:controller="com.android.settings.display.TouchPollingPreferenceController" />
+
         <com.evolution.settings.preference.GlobalSettingSwitchPreference
             android:key="wake_when_plugged_or_unplugged"
             android:title="@string/wake_when_plugged_or_unplugged_title"

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -154,6 +154,14 @@
             settings:keywords="@string/keywords_screen_resolution"
             settings:controller="com.android.settings.display.ScreenResolutionController"/>
 
+        <com.android.settings.display.DcDimmingPreference
+            android:key="dc_dimming"
+            android:title="@string/dc_dimming_title"
+            android:fragment="com.android.settings.display.DcDimmingSettings"
+            android:widgetLayout="@null"
+            settings:widgetLayout="@null"
+            settings:keywords="@string/keywords_display_dc_dimming"/>
+
         <SwitchPreferenceCompat
             android:key="display_white_balance"
             android:title="@string/display_white_balance_title"

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -196,6 +196,12 @@
             android:title="@string/tap_to_wake"
             android:summary="@string/tap_to_wake_summary"/>
 
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="proximity_on_wake"
+            android:title="@string/proximity_wake_title"
+            android:summary="@string/proximity_wake_summary"
+            android:defaultValue="@*android:bool/config_proximityCheckOnWakeEnabledByDefault" />
+
         <Preference
             android:key="display_cutout_force_fullscreen_settings"
             android:title="@string/display_cutout_force_fullscreen_title"

--- a/res/xml/double_tap_screen_settings.xml
+++ b/res/xml/double_tap_screen_settings.xml
@@ -31,4 +31,10 @@
         app:keywords="@string/keywords_gesture"
         app:controller="com.android.settings.gestures.DoubleTapScreenPreferenceController" />
 
+    <com.evolution.settings.preference.SecureSettingSwitchPreference
+        android:key="doze_double_tap_gesture_ambient"
+        android:title="@string/doze_gesture_ambient_title"
+        android:summary="@string/doze_gesture_ambient_summary"
+        android:defaultValue="false" />
+
 </PreferenceScreen>

--- a/res/xml/extra_dim_schedule.xml
+++ b/res/xml/extra_dim_schedule.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2023 Yet Another AOSP Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:settings="http://schemas.android.com/apk/res/com.android.settings"
+    android:title="@string/extra_dim_schedule_title">
+
+    <com.evolution.settings.preference.SecureSettingListPreference
+            android:key="extra_dim_auto_mode"
+            android:title="@string/night_display_auto_mode_title"
+            android:dialogTitle="@string/night_display_auto_mode_title"
+            android:entries="@array/doze_always_on_auto_mode_entries"
+            android:entryValues="@array/doze_always_on_auto_mode_values"
+            android:persistent="false" />
+
+    <Preference
+        android:key="extra_dim_auto_since"
+        android:title="@string/night_display_start_time_title" />
+
+    <Preference
+        android:key="extra_dim_auto_till"
+        android:title="@string/night_display_end_time_title" />
+
+</PreferenceScreen>

--- a/res/xml/gesture_nav_tweaks.xml
+++ b/res/xml/gesture_nav_tweaks.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2017-2019 The Dirty Unicorns Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:settings="http://schemas.android.com/apk/res/com.android.settings"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:title="@string/navbar_gesture_tweaks_pref_title" >
+
+    <com.evolution.settings.preference.SystemSettingSwitchPreference
+        android:key="back_swipe_extended"
+        android:title="@string/back_swipe_extended_title"
+        android:summary="@string/back_swipe_extended_summary"
+        android:defaultValue="false" />
+
+    <com.evolution.settings.preference.SystemSettingListPreference
+        android:key="long_back_swipe_timeout"
+        android:title="@string/long_back_swipe_timeout_title"
+        android:entries="@array/long_back_swipe_timeout_entries"
+        android:entryValues="@array/long_back_swipe_timeout_values"
+        android:defaultValue="2000" />
+
+    <ListPreference
+        android:key="left_swipe_actions"
+        android:title="@string/left_swipe_actions_title"
+        android:entries="@array/swipe_actions_entries"
+        android:entryValues="@array/swipe_actions_values"
+        android:defaultValue="0" />
+
+    <Preference
+        android:key="left_swipe_app_action"
+        android:title="@string/left_swipe_app_action_title"
+        android:summary="@string/swipe_app_select_summary">
+        <intent android:action="android.intent.action.MAIN"
+            android:targetPackage="com.android.systemui"
+            android:targetClass="com.android.systemui.statusbar.phone.LeftBackSwipeCustomApp" />
+    </Preference>
+
+    <ListPreference
+        android:key="right_swipe_actions"
+        android:title="@string/right_swipe_actions_title"
+        android:entries="@array/swipe_actions_entries"
+        android:entryValues="@array/swipe_actions_values"
+        android:defaultValue="0" />
+
+    <Preference
+        android:key="right_swipe_app_action"
+        android:title="@string/right_swipe_app_action_title"
+        android:summary="@string/swipe_app_select_summary">
+        <intent android:action="android.intent.action.MAIN"
+            android:targetPackage="com.android.systemui"
+            android:targetClass="com.android.systemui.statusbar.phone.RightBackSwipeCustomApp" />
+    </Preference>
+
+    <ListPreference
+        android:key="left_vertical_swipe_actions"
+        android:title="@string/left_vertical_swipe_actions_title"
+        android:entries="@array/swipe_actions_entries"
+        android:entryValues="@array/swipe_actions_values"
+        android:defaultValue="0" />
+
+    <Preference
+        android:key="left_vertical_swipe_app_action"
+        android:title="@string/left_vertical_swipe_app_action_title"
+        android:summary="@string/swipe_app_select_summary">
+        <intent android:action="android.intent.action.MAIN"
+            android:targetPackage="com.android.systemui"
+            android:targetClass="com.android.systemui.statusbar.phone.LeftBackVerticalSwipeCustomApp" />
+    </Preference>
+
+    <ListPreference
+        android:key="right_vertical_swipe_actions"
+        android:title="@string/right_vertical_swipe_actions_title"
+        android:entries="@array/swipe_actions_entries"
+        android:entryValues="@array/swipe_actions_values"
+        android:defaultValue="0" />
+
+    <Preference
+        android:key="right_vertical_swipe_app_action"
+        android:title="@string/right_vertical_swipe_app_action_title"
+        android:summary="@string/swipe_app_select_summary">
+        <intent android:action="android.intent.action.MAIN"
+            android:targetPackage="com.android.systemui"
+            android:targetClass="com.android.systemui.statusbar.phone.RightBackVerticalSwipeCustomApp" />
+    </Preference>
+
+    <com.android.settingslib.widget.FooterPreference
+        android:title="@string/gesture_nav_tweaks_footer_info" />
+</PreferenceScreen>

--- a/res/xml/gesture_nav_tweaks.xml
+++ b/res/xml/gesture_nav_tweaks.xml
@@ -25,13 +25,6 @@
         android:summary="@string/back_swipe_extended_summary"
         android:defaultValue="false" />
 
-    <com.evolution.settings.preference.SystemSettingListPreference
-        android:key="long_back_swipe_timeout"
-        android:title="@string/long_back_swipe_timeout_title"
-        android:entries="@array/long_back_swipe_timeout_entries"
-        android:entryValues="@array/long_back_swipe_timeout_values"
-        android:defaultValue="2000" />
-
     <ListPreference
         android:key="left_swipe_actions"
         android:title="@string/left_swipe_actions_title"

--- a/res/xml/gesture_navigation_settings.xml
+++ b/res/xml/gesture_navigation_settings.xml
@@ -23,6 +23,12 @@
     android:title="@string/edge_to_edge_navigation_title"
     settings:keywords="@string/keywords_gesture_navigation_settings">
 
+    <Preference
+        android:key="gesture_nav_custom_options"
+        android:title="@string/navbar_gesture_tweaks_pref_title"
+        android:summary="@string/navbar_gesture_tweaks_pref_summary"
+        android:fragment="com.android.settings.gestures.GestureTweaksSettings" />
+
     <com.evolution.settings.preference.SystemSettingSwitchPreference
         android:key="navigation_bar_hint"
         android:title="@string/show_navbar_hint_title"

--- a/res/xml/mobile_network_settings.xml
+++ b/res/xml/mobile_network_settings.xml
@@ -223,7 +223,7 @@
                 android:title="@string/select_automatically"
                 settings:controller="com.android.settings.network.telephony.gsm.AutoSelectPreferenceController"/>
 
-            <SwitchPreference
+            <SwitchPreferenceCompat
                 android:key="force_lteca_key"
                 android:title="@string/force_lte_ca"
                 android:summary="@string/force_lte_ca_summary"

--- a/res/xml/my_device_info.xml
+++ b/res/xml/my_device_info.xml
@@ -157,13 +157,13 @@
             settings:controller="com.android.settings.deviceinfo.firmwareversion.FirmwareVersionPreferenceController"/>
 
         <!-- Battery information -->
-        <Preference
+        <!--<Preference
             android:key="battery_info"
             android:order="43"
             android:title="@string/battery_info"
             android:fragment="com.android.settings.deviceinfo.batteryinfo.BatteryInfoFragment"
             settings:keywords="@string/keywords_battery_info"
-            settings:controller="com.android.settings.deviceinfo.batteryinfo.BatteryInfoPreferenceController"/>
+            settings:controller="com.android.settings.deviceinfo.batteryinfo.BatteryInfoPreferenceController"/>-->
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/res/xml/my_device_info.xml
+++ b/res/xml/my_device_info.xml
@@ -192,18 +192,14 @@
             android:key="wifi_mac_address"
             android:order="46"
             android:title="@string/status_device_wifi_mac_address"
-            android:summary="@string/summary_placeholder"
-            android:selectable="false"
-            settings:enableCopying="true"/>
+            android:summary="@string/summary_placeholder"/>
 
         <!-- Bluetooth address -->
         <Preference
             android:key="bt_address"
             android:order="47"
             android:title="@string/status_bt_address"
-            android:summary="@string/summary_placeholder"
-            android:selectable="false"
-            settings:enableCopying="true"/>
+            android:summary="@string/summary_placeholder"/>
 
         <!-- Device up time -->
         <Preference

--- a/res/xml/notification_charge_level_settings.xml
+++ b/res/xml/notification_charge_level_settings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2019-2022 Evolution X
+     SPDX-License-Identifier: Apache-2.0
+-->
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:settings="http://schemas.android.com/apk/res/com.android.settings"
+    android:title="@string/notification_battery_charge_level_title" >
+
+    <com.android.settingslib.widget.TopIntroPreference
+        android:key="notification_battery_charge_level_summary_intro_text"
+        android:title="@string/notification_battery_charge_level_summary" />
+
+    <com.evolution.settings.preference.SystemSettingMainSwitchPreference
+        android:key="battery_level_charge_alarm_enabled"
+        android:title="@string/notification_battery_charge_level_main_switch_title"
+        android:defaultValue="false" />
+
+    <Preference
+        android:key="battery_level_charge_ringtone"
+        android:title="@string/notification_battery_charge_level_ringtone"
+        android:dependency="battery_level_charge_alarm_enabled" />
+
+    <com.evolution.settings.preference.CustomSeekBarPreference
+        android:key="battery_level_charge_seek_bar"
+        android:title="@string/notification_battery_charge_level_seek_bar"
+        android:max="100"
+        settings:min="0"
+        settings:units="%"
+        android:dependency="battery_level_charge_alarm_enabled"/>
+
+</PreferenceScreen>

--- a/res/xml/notification_light_settings.xml
+++ b/res/xml/notification_light_settings.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2016 The CyanogenMod Project
+                   2017-2018,2021-2022 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+        android:key="notification_lights"
+        android:title="@string/notification_light_title">
+
+    <com.evolution.settings.preference.SystemSettingMainSwitchPreference
+        android:key="notification_light_pulse"
+        android:title="@string/notification_light_enable_title" />
+
+    <PreferenceCategory
+        android:key="general_section"
+        android:title="@string/notification_light_general_title">
+
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="notification_light_color_auto"
+            android:title="@string/notification_light_automagic"
+            android:dependency="notification_light_pulse"
+            android:defaultValue="true" />
+
+        <com.android.settings.evolution.notificationlight.ApplicationLightPreference
+            android:key="default"
+            android:title="@string/notification_light_default_value"
+            android:persistent="false"
+            android:dependency="notification_light_pulse" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="brightness_section"
+        android:title="@string/light_brightness_title"
+        android:dependency="notification_light_pulse" >
+
+        <com.android.settings.evolution.notificationlight.NotificationBrightnessPreference
+            android:key="notification_light_brightness_level"
+            android:title="@string/notification_light_brightness_normal"
+            android:dependency="notification_light_pulse" />
+
+        <com.android.settings.evolution.notificationlight.NotificationBrightnessZenPreference
+            android:key="notification_light_brightness_level_zen"
+            android:title="@string/notification_light_brightness_zen"
+            android:dependency="notification_light_pulse" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="advanced_section"
+        android:title="@string/notification_light_advanced_title">
+
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="notification_light_screen_on_enable"
+            android:title="@string/notification_light_screen_on"
+            android:dependency="notification_light_pulse" />
+
+        <com.evolution.settings.preference.SystemSettingSwitchPreference
+            android:key="notification_light_pulse_custom_enable"
+            android:title="@string/notification_light_use_custom"
+            android:dependency="notification_light_pulse" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="phone_list"
+        android:title="@string/notification_light_phonelist_title" >
+
+        <com.android.settings.evolution.notificationlight.ApplicationLightPreference
+            android:key="missed_call"
+            android:title="@string/notification_light_missed_call_title"
+            android:persistent="false"
+            android:dependency="notification_light_pulse_custom_enable" />
+
+        <com.android.settings.evolution.notificationlight.ApplicationLightPreference
+            android:key="voicemail"
+            android:title="@string/notification_light_voicemail_title"
+            android:persistent="false"
+            android:dependency="notification_light_pulse_custom_enable" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="applications_list"
+        android:title="@string/notification_light_applist_title"
+        android:dependency="notification_light_pulse_custom_enable" >
+
+        <Preference
+            android:key="custom_apps_add"
+            android:title="@string/add"
+            android:icon="@drawable/ic_add_24dp" />
+
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/res/xml/pick_up_gesture_settings.xml
+++ b/res/xml/pick_up_gesture_settings.xml
@@ -34,4 +34,10 @@
         app:keywords="@string/keywords_gesture"
         app:controller="com.android.settings.gestures.PickupGesturePreferenceController" />
 
+    <com.evolution.settings.preference.SecureSettingSwitchPreference
+        android:key="doze_pick_up_gesture_ambient"
+        android:title="@string/doze_gesture_ambient_title"
+        android:summary="@string/doze_gesture_ambient_summary"
+        android:defaultValue="false" />
+
 </PreferenceScreen>

--- a/res/xml/power_usage_summary.xml
+++ b/res/xml/power_usage_summary.xml
@@ -101,6 +101,12 @@
         android:summary="@string/battery_percentage_description"
         settings:controller="com.android.settings.display.BatteryPercentagePreferenceController" />
 
+    <Preference
+        android:key="battery_info"
+        android:title="@string/battery_info"
+        android:fragment="com.android.settings.deviceinfo.batteryinfo.BatteryInfoFragment"
+        settings:keywords="@string/keywords_battery_info"/>
+
     <com.android.settingslib.widget.FooterPreference
         android:key="power_usage_footer"
         android:title="@string/battery_footer_summary"

--- a/res/xml/power_usage_summary.xml
+++ b/res/xml/power_usage_summary.xml
@@ -59,6 +59,21 @@
         android:fragment="com.android.settings.health.ChargingControlSettings"
         settings:controller="com.android.settings.health.ChargingControlPreferenceController" />
 
+    <Preference
+        android:key="fast_charging"
+        android:title="@string/fast_charging_title"
+        android:summary="@string/fast_charging_summary"
+        android:fragment="com.android.settings.fuelgauge.fastcharge.FastChargingSettings"
+        settings:controller="com.android.settings.fuelgauge.FastChargingPreferenceController"/>
+
+    <com.evolution.settings.preference.SystemSettingPrimarySwitchPreference
+        android:key="battery_level_charge_alarm_enabled"
+        android:title="@string/notification_battery_charge_level_title"
+        android:summary="@string/notification_battery_charge_level_summary"
+        android:defaultValue="false"
+        android:fragment="com.android.settings.fuelgauge.BatteryChargeSoundSettings"
+        settings:observe="true" />
+
     <!-- Sleep Mode -->
     <Preference
         android:key="sleep_mode"
@@ -67,7 +82,8 @@
 
     <Preference
         android:key="high_power_apps"
-        android:title="@string/high_power_apps">
+        android:title="@string/high_power_apps"
+        android:summary="@string/high_power_apps_summary">
         <intent android:action="android.settings.IGNORE_BATTERY_OPTIMIZATION_SETTINGS" />
     </Preference>
 

--- a/res/xml/power_usage_summary.xml
+++ b/res/xml/power_usage_summary.xml
@@ -87,6 +87,14 @@
         <intent android:action="android.settings.IGNORE_BATTERY_OPTIMIZATION_SETTINGS" />
     </Preference>
 
+    <!-- Battery light -->
+    <Preference
+        android:key="battery_lights"
+        android:title="@string/battery_light_title"
+        android:summary="@string/battery_light_summary"
+        android:fragment="com.android.settings.evolution.notificationlight.BatteryLightSettings"
+        settings:controller="com.android.settings.evolution.notificationlight.BatteryLightPreferenceController" />
+
     <SwitchPreferenceCompat
         android:key="battery_percentage"
         android:title="@string/battery_percentage"

--- a/res/xml/refresh_rate_settings.xml
+++ b/res/xml/refresh_rate_settings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2022 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:settings="http://schemas.android.com/apk/res-auto"
+    android:title="@string/refresh_rate_title"
+    android:key="refresh_rate"
+    settings:staticPreferenceLocation="append" />

--- a/res/xml/screen_lock_settings.xml
+++ b/res/xml/screen_lock_settings.xml
@@ -39,7 +39,7 @@
     <SwitchPreferenceCompat
         android:key="auto_pin_confirm"
         android:title="@string/lock_screen_auto_pin_confirm_title"
-        android:summary="@string/lock_screen_auto_pin_confirm_summary" />
+        android:summary="@string/lock_screen_auto_pin_confirm_summary_custom" />
 
     <SwitchPreferenceCompat
         android:key="enhancedPinPrivacy"

--- a/res/xml/sound_settings.xml
+++ b/res/xml/sound_settings.xml
@@ -139,6 +139,16 @@
         android:order="-120"
         settings:keywords="@string/sound_settings"/>
 
+    <!-- Phone ringtone for Slot2 -->
+    <com.android.settings.DefaultRingtonePreference
+        android:key="ringtone2"
+        android:title="@string/ringtone2_title"
+        android:dialogTitle="@string/ringtone_title"
+        android:summary="@string/summary_placeholder"
+        android:ringtoneType="ringtone"
+        settings:allowDividerAbove="false"
+        android:order="-119"/>
+
     <!-- Adaptive Playback -->
     <Preference
         android:key="sound_adaptive_playback_summary"

--- a/res/xml/sound_settings.xml
+++ b/res/xml/sound_settings.xml
@@ -243,6 +243,12 @@
         android:key="screenshot_shutter_sound"
         android:title="@string/screenshot_shutter_sound_title"
         android:defaultValue="true"
+        android:order="-29"/>
+
+    <!-- NFC sounds -->
+    <SwitchPreference
+        android:key="nfc_sounds"
+        android:title="@string/nfc_sounds_title"
         android:order="-28"/>
 
     <!-- Show vibrate icon in status bar -->

--- a/res/xml/sound_settings.xml
+++ b/res/xml/sound_settings.xml
@@ -110,6 +110,14 @@
         android:order="-135"
         settings:controller="com.android.settings.notification.IncreasingRingVolumePreferenceController" />
 
+    <!-- Volume steps -->
+    <Preference
+        android:key="volume_steps"
+        android:title="@string/volume_steps_title"
+        android:summary="@string/volume_steps_summary"
+        android:fragment="com.android.settings.sound.VolumeSteps"
+        android:order="-134"/>
+
     <!-- TODO(b/174964721): make this a PrimarySwitchPreference -->
     <!-- Interruptions -->
     <com.android.settingslib.RestrictedPreference

--- a/res/xml/tap_screen_gesture_settings.xml
+++ b/res/xml/tap_screen_gesture_settings.xml
@@ -33,4 +33,10 @@
         app:keywords="@string/keywords_gesture"
         app:controller="com.android.settings.gestures.TapScreenGesturePreferenceController" />
 
+    <com.evolution.settings.preference.SecureSettingSwitchPreference
+        android:key="doze_single_tap_gesture_ambient"
+        android:title="@string/doze_gesture_ambient_title"
+        android:summary="@string/doze_gesture_ambient_summary"
+        android:defaultValue="false" />
+
 </PreferenceScreen>

--- a/res/xml/volume_steps_settings.xml
+++ b/res/xml/volume_steps_settings.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2024 Yet Another AOSP Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:settings="http://schemas.android.com/apk/res/com.android.settings"
+    android:title="@string/volume_steps_title">
+
+    <com.evolution.settings.preference.CustomSeekBarPreference
+        android:key="max_music_volume"
+        android:title="@string/max_music_volume_title"
+        android:max="100"
+        settings:min="15"
+        settings:interval="5"
+        settings:units="@string/steps_unit" />
+
+    <com.evolution.settings.preference.CustomSeekBarPreference
+        android:key="max_call_volume"
+        android:title="@string/max_call_volume_title"
+        android:max="30"
+        settings:min="5"
+        settings:interval="1"
+        settings:units="@string/steps_unit" />
+
+    <com.evolution.settings.preference.CustomSeekBarPreference
+        android:key="max_alarm_volume"
+        android:title="@string/max_alarm_volume_title"
+        android:max="30"
+        settings:min="7"
+        settings:interval="1"
+        settings:units="@string/steps_unit" />
+
+</PreferenceScreen>

--- a/res/xml/wifi_network_details_fragment2.xml
+++ b/res/xml/wifi_network_details_fragment2.xml
@@ -94,7 +94,7 @@
         android:key="privacy"
         android:icon="@drawable/ic_wifi_privacy_24dp"
         android:title="@string/wifi_privacy_settings"
-        android:entries="@array/wifi_privacy_entries"
+        android:entries="@array/wifi_privacy_entries_extended"
         android:entryValues="@array/wifi_privacy_values"/>
 
     <Preference

--- a/src/com/android/settings/DefaultRingtonePreference.java
+++ b/src/com/android/settings/DefaultRingtonePreference.java
@@ -62,12 +62,14 @@ public class DefaultRingtonePreference extends RingtonePreference {
 
     @VisibleForTesting
     void setActualDefaultRingtoneUri(Uri ringtoneUri) {
-        RingtoneManager.setActualDefaultRingtoneUri(mUserContext, getRingtoneType(), ringtoneUri);
+        RingtoneManager.setActualDefaultRingtoneUriBySlot(mUserContext, getRingtoneType(),
+                ringtoneUri, getSlotId());
     }
 
     @Override
     protected Uri onRestoreRingtone() {
-        return RingtoneManager.getActualDefaultRingtoneUri(mUserContext, getRingtoneType());
+        return RingtoneManager.getActualDefaultRingtoneUriBySlot(mUserContext, getRingtoneType(),
+                getSlotId());
     }
 
 }

--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -20,6 +20,8 @@ import android.app.settings.SettingsEnums;
 import android.content.Context;
 import android.os.Bundle;
 
+import androidx.preference.Preference;
+
 import com.android.settings.dashboard.DashboardFragment;
 import com.android.settings.display.BrightnessLevelPreferenceController;
 import com.android.settings.display.CameraGesturePreferenceController;
@@ -46,6 +48,8 @@ public class DisplaySettings extends DashboardFragment {
     private static final String KEY_HIGH_TOUCH_POLLING_RATE = "high_touch_polling_rate_enable";
     private static final String KEY_HIGH_TOUCH_SENSITIVITY = "high_touch_sensitivity_enable";
 
+    public static final String KEY_PROXIMITY_ON_WAKE = "proximity_on_wake";
+
     @Override
     public int getMetricsCategory() {
         return SettingsEnums.DISPLAY;
@@ -64,6 +68,15 @@ public class DisplaySettings extends DashboardFragment {
     @Override
     public void onCreate(Bundle icicle) {
         super.onCreate(icicle);
+
+        final Preference proximityWakePreference =
+                (Preference) getPreferenceScreen().findPreference(KEY_PROXIMITY_ON_WAKE);
+        final boolean enableProximityOnWake =
+                getResources().getBoolean(com.android.internal.R.bool.config_proximityCheckOnWake);
+
+        if (!enableProximityOnWake && proximityWakePreference != null){
+            getPreferenceScreen().removePreference(proximityWakePreference);
+        }
     }
 
     @Override
@@ -96,6 +109,10 @@ public class DisplaySettings extends DashboardFragment {
                 @Override
                 public List<String> getNonIndexableKeys(Context context) {
                     List<String> keys = super.getNonIndexableKeys(context);
+                    if (!context.getResources().getBoolean(
+                            com.android.internal.R.bool.config_proximityCheckOnWake)) {
+                        keys.add(KEY_PROXIMITY_ON_WAKE);
+                    }
                     LineageHardwareManager hardware = LineageHardwareManager.getInstance(context);
                     if (!hardware.isSupported(
                             LineageHardwareManager.FEATURE_HIGH_TOUCH_POLLING_RATE)) {

--- a/src/com/android/settings/IntervalSeekBar.java
+++ b/src/com/android/settings/IntervalSeekBar.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2017 The Pure Nexus Project
+ * Copyright (C) 2016 The CyanogenMod Project
+ *               2017-2022 The LineageOS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +31,8 @@ import android.widget.SeekBar;
 public class IntervalSeekBar extends SeekBar {
     private float mMin;
     private float mMax;
-    private float mDefault;
-    private float mMultiplier;
+    private final float mDefault;
+    private final float mMultiplier;
 
     public IntervalSeekBar(Context context, AttributeSet attrs) {
         super(context, attrs);

--- a/src/com/android/settings/RingtonePreference.java
+++ b/src/com/android/settings/RingtonePreference.java
@@ -40,6 +40,7 @@ import androidx.preference.PreferenceManager;
  * <p>
  * If the user chooses the "Default" item, the saved string will be one of
  * {@link System#DEFAULT_RINGTONE_URI},
+ * {@link System#DEFAULT_RINGTONE2_URI},
  * {@link System#DEFAULT_NOTIFICATION_URI}, or
  * {@link System#DEFAULT_ALARM_ALERT_URI}. If the user chooses the "Silent"
  * item, the saved string will be an empty string.
@@ -54,6 +55,9 @@ import androidx.preference.PreferenceManager;
 public class RingtonePreference extends Preference {
 
     private static final String TAG = "RingtonePreference";
+
+    // Default is slot0
+    private int mSlotId = 0;
 
     private int mRingtoneType;
     private boolean mShowDefault;
@@ -86,6 +90,25 @@ public class RingtonePreference extends Preference {
 
     public int getUserId() {
         return mUserId;
+    }
+
+    /**
+     * Sets the slot id that this preference belongs to.
+     *
+     * @param slotId The slot id that this preference belongs to.
+     */
+    public void setSlotId(int slotId) {
+        mSlotId = slotId;
+    }
+
+    /**
+     * Returns the slot id that this preference belongs to.
+     *
+     * @return The slot id that this preference belongs to.
+     * @see #setSlotId(int)
+     */
+    public int getSlotId() {
+        return mSlotId;
     }
 
     /**
@@ -166,7 +189,7 @@ public class RingtonePreference extends Preference {
         ringtonePickerIntent.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_DEFAULT, mShowDefault);
         if (mShowDefault) {
             ringtonePickerIntent.putExtra(RingtoneManager.EXTRA_RINGTONE_DEFAULT_URI,
-                    RingtoneManager.getDefaultUri(getRingtoneType()));
+                    RingtoneManager.getDefaultUriBySlot(getRingtoneType(), getSlotId()));
         }
 
         ringtonePickerIntent.putExtra(RingtoneManager.EXTRA_RINGTONE_SHOW_SILENT, mShowSilent);

--- a/src/com/android/settings/Settings.java
+++ b/src/com/android/settings/Settings.java
@@ -90,6 +90,7 @@ public class Settings extends SettingsActivity {
     public static class NightDisplaySuggestionActivity extends NightDisplaySettingsActivity { /* empty */ }
     public static class SmartAutoRotateSettingsActivity extends SettingsActivity { /* empty */ }
     public static class DcDimmingSettingsActivity extends SettingsActivity { /* empty */ }
+    public static class RefreshRateSettingsActivity extends SettingsActivity { /* empty */ }
     public static class MyDeviceInfoActivity extends SettingsActivity { /* empty */ }
     public static class ModuleLicensesActivity extends SettingsActivity { /* empty */ }
     public static class ApplicationSettingsActivity extends SettingsActivity { /* empty */ }

--- a/src/com/android/settings/Settings.java
+++ b/src/com/android/settings/Settings.java
@@ -89,6 +89,7 @@ public class Settings extends SettingsActivity {
     public static class NightDisplaySettingsActivity extends SettingsActivity { /* empty */ }
     public static class NightDisplaySuggestionActivity extends NightDisplaySettingsActivity { /* empty */ }
     public static class SmartAutoRotateSettingsActivity extends SettingsActivity { /* empty */ }
+    public static class DcDimmingSettingsActivity extends SettingsActivity { /* empty */ }
     public static class MyDeviceInfoActivity extends SettingsActivity { /* empty */ }
     public static class ModuleLicensesActivity extends SettingsActivity { /* empty */ }
     public static class ApplicationSettingsActivity extends SettingsActivity { /* empty */ }

--- a/src/com/android/settings/Settings.java
+++ b/src/com/android/settings/Settings.java
@@ -488,6 +488,7 @@ public class Settings extends SettingsActivity {
     public static class EvolutionSettingsActivity extends SettingsActivity {}
     public static class HeadsUpSettingsActivity extends SettingsActivity { /* empty */ }
     public static class SmartPixelsActivity extends SettingsActivity {}
+    public static class WirelessDebuggingActivity extends SettingsActivity { /* empty */ }
 
     /**
      * Activity for PreviouslyConnectedDeviceDashboardFragment

--- a/src/com/android/settings/Settings.java
+++ b/src/com/android/settings/Settings.java
@@ -489,6 +489,7 @@ public class Settings extends SettingsActivity {
     public static class HeadsUpSettingsActivity extends SettingsActivity { /* empty */ }
     public static class SmartPixelsActivity extends SettingsActivity {}
     public static class WirelessDebuggingActivity extends SettingsActivity { /* empty */ }
+    public static class DevRunningServicesActivity extends SettingsActivity { /* empty */ }
 
     /**
      * Activity for PreviouslyConnectedDeviceDashboardFragment

--- a/src/com/android/settings/accessibility/ColorInversionPreferenceController.java
+++ b/src/com/android/settings/accessibility/ColorInversionPreferenceController.java
@@ -42,6 +42,8 @@ public class ColorInversionPreferenceController extends BasePreferenceController
 
     @Override
     public int getAvailabilityStatus() {
-        return AVAILABLE;
+        final boolean available = mContext.getResources().getBoolean(
+                com.android.internal.R.bool.config_displayInversionAvailable);
+        return available ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
     }
 }

--- a/src/com/android/settings/accessibility/ExtraDimScheduleFragment.java
+++ b/src/com/android/settings/accessibility/ExtraDimScheduleFragment.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2021 Yet Another AOSP Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.settings.accessibility;
+
+import static com.android.internal.util.evolution.AutoSettingConsts.MODE_DISABLED;
+import static com.android.internal.util.evolution.AutoSettingConsts.MODE_NIGHT;
+import static com.android.internal.util.evolution.AutoSettingConsts.MODE_TIME;
+import static com.android.internal.util.evolution.AutoSettingConsts.MODE_MIXED_SUNSET;
+import static com.android.internal.util.evolution.AutoSettingConsts.MODE_MIXED_SUNRISE;
+
+import android.app.TimePickerDialog;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.os.Bundle;
+import android.os.UserHandle;
+import android.provider.Settings;
+import android.text.format.DateFormat;
+import android.widget.TimePicker;
+
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+
+import com.android.internal.logging.nano.MetricsProto;
+import com.android.settings.dashboard.DashboardFragment;
+import com.android.settings.R;
+import com.android.settings.search.BaseSearchIndexProvider;
+import com.android.settingslib.search.SearchIndexable;
+
+import com.evolution.settings.preference.SecureSettingListPreference;
+
+import java.time.format.DateTimeFormatter;
+import java.time.LocalTime;
+
+@SearchIndexable
+public class ExtraDimScheduleFragment extends DashboardFragment implements
+        Preference.OnPreferenceClickListener, Preference.OnPreferenceChangeListener {
+
+    private static final String TAG = "ExtraDimScheduleFragment";
+    private static final String MODE_KEY = "extra_dim_auto_mode";
+    private static final String SINCE_PREF_KEY = "extra_dim_auto_since";
+    private static final String TILL_PREF_KEY = "extra_dim_auto_till";
+
+    private SecureSettingListPreference mModePref;
+    private Preference mSincePref;
+    private Preference mTillPref;
+
+    @Override
+    protected int getPreferenceScreenResId() {
+        return R.xml.extra_dim_schedule;
+    }
+
+    @Override
+    public void onCreate(Bundle icicle) {
+        super.onCreate(icicle);
+
+        PreferenceScreen screen = getPreferenceScreen();
+        ContentResolver resolver = getActivity().getContentResolver();
+
+        mSincePref = findPreference(SINCE_PREF_KEY);
+        mSincePref.setOnPreferenceClickListener(this);
+        mTillPref = findPreference(TILL_PREF_KEY);
+        mTillPref.setOnPreferenceClickListener(this);
+
+        int mode = Settings.Secure.getIntForUser(resolver,
+                MODE_KEY, MODE_DISABLED, UserHandle.USER_CURRENT);
+        mModePref = findPreference(MODE_KEY);
+        mModePref.setValue(String.valueOf(mode));
+        mModePref.setSummary(mModePref.getEntry());
+        mModePref.setOnPreferenceChangeListener(this);
+
+        updateTimeEnablement(mode);
+        updateTimeSummary(mode);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object objValue) {
+        int value = Integer.parseInt((String) objValue);
+        int index = mModePref.findIndexOfValue((String) objValue);
+        mModePref.setSummary(mModePref.getEntries()[index]);
+        Settings.Secure.putIntForUser(getActivity().getContentResolver(),
+                MODE_KEY, value, UserHandle.USER_CURRENT);
+        updateTimeEnablement(value);
+        updateTimeSummary(value);
+        return true;
+    }
+
+    @Override
+    public boolean onPreferenceClick(Preference preference) {
+        String[] times = getCustomTimeSetting();
+        boolean isSince = preference == mSincePref;
+        int hour, minute;
+        TimePickerDialog.OnTimeSetListener listener = (view, hourOfDay, minute1) -> {
+            updateTimeSetting(isSince, hourOfDay, minute1);
+        };
+        if (isSince) {
+            String[] sinceValues = times[0].split(":", 0);
+            hour = Integer.parseInt(sinceValues[0]);
+            minute = Integer.parseInt(sinceValues[1]);
+        } else {
+            String[] tillValues = times[1].split(":", 0);
+            hour = Integer.parseInt(tillValues[0]);
+            minute = Integer.parseInt(tillValues[1]);
+        }
+        TimePickerDialog dialog = new TimePickerDialog(getContext(), listener,
+                hour, minute, DateFormat.is24HourFormat(getContext()));
+        dialog.show();
+        return true;
+    }
+
+    private String[] getCustomTimeSetting() {
+        String value = Settings.Secure.getStringForUser(getActivity().getContentResolver(),
+                Settings.Secure.EXTRA_DIM_AUTO_TIME, UserHandle.USER_CURRENT);
+        if (value == null || value.equals("")) value = "20:00,07:00";
+        return value.split(",", 0);
+    }
+
+    private void updateTimeEnablement(int mode) {
+        mSincePref.setEnabled(mode == MODE_TIME || mode == MODE_MIXED_SUNRISE);
+        mTillPref.setEnabled(mode == MODE_TIME || mode == MODE_MIXED_SUNSET);
+    }
+
+    private void updateTimeSummary(int mode) {
+        updateTimeSummary(getCustomTimeSetting(), mode);
+    }
+
+    private void updateTimeSummary(String[] times, int mode) {
+        if (mode == MODE_DISABLED) {
+            mSincePref.setSummary("-");
+            mTillPref.setSummary("-");
+            return;
+        }
+
+        if (mode == MODE_NIGHT) {
+            mSincePref.setSummary(R.string.always_on_display_schedule_sunset);
+            mTillPref.setSummary(R.string.always_on_display_schedule_sunrise);
+            return;
+        }
+
+        String outputFormat = DateFormat.is24HourFormat(getContext()) ? "HH:mm" : "hh:mm a";
+        DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern(outputFormat);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+        LocalTime sinceDT = LocalTime.parse(times[0], formatter);
+        LocalTime tillDT = LocalTime.parse(times[1], formatter);
+
+        if (mode == MODE_MIXED_SUNSET) {
+            mSincePref.setSummary(R.string.always_on_display_schedule_sunset);
+            mTillPref.setSummary(tillDT.format(outputFormatter));
+        } else if (mode == MODE_MIXED_SUNRISE) {
+            mTillPref.setSummary(R.string.always_on_display_schedule_sunrise);
+            mSincePref.setSummary(sinceDT.format(outputFormatter));
+        } else {
+            mSincePref.setSummary(sinceDT.format(outputFormatter));
+            mTillPref.setSummary(tillDT.format(outputFormatter));
+        }
+    }
+
+    private void updateTimeSetting(boolean since, int hour, int minute) {
+        String[] times = getCustomTimeSetting();
+        String nHour = "";
+        String nMinute = "";
+        if (hour < 10) nHour += "0";
+        if (minute < 10) nMinute += "0";
+        nHour += String.valueOf(hour);
+        nMinute += String.valueOf(minute);
+        times[since ? 0 : 1] = nHour + ":" + nMinute;
+        Settings.Secure.putStringForUser(getActivity().getContentResolver(),
+                Settings.Secure.EXTRA_DIM_AUTO_TIME,
+                times[0] + "," + times[1], UserHandle.USER_CURRENT);
+        updateTimeSummary(times, Integer.parseInt(mModePref.getValue()));
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsProto.MetricsEvent.EVO_SETTINGS;
+    }
+
+    @Override
+    protected String getLogTag() {
+        return TAG;
+    }
+
+    public static final BaseSearchIndexProvider SEARCH_INDEX_DATA_PROVIDER =
+            new BaseSearchIndexProvider(R.xml.extra_dim_schedule);
+}

--- a/src/com/android/settings/accessibility/VibrationSettings.java
+++ b/src/com/android/settings/accessibility/VibrationSettings.java
@@ -18,6 +18,8 @@ package com.android.settings.accessibility;
 
 import android.app.settings.SettingsEnums;
 import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.Vibrator;
@@ -29,20 +31,30 @@ import android.view.ViewGroup;
 import androidx.annotation.VisibleForTesting;
 import androidx.recyclerview.widget.RecyclerView;
 
+import androidx.preference.Preference;
+
+import com.android.internal.util.evolution.EvolutionUtils;
 import com.android.settings.R;
 import com.android.settings.dashboard.DashboardFragment;
 import com.android.settings.flags.Flags;
 import com.android.settings.search.BaseSearchIndexProvider;
 import com.android.settingslib.search.SearchIndexable;
 
+import com.evolution.settings.preference.SystemSettingSwitchPreference;
+
 import java.util.ArrayList;
 import java.util.List;
 
 /** Accessibility settings for the vibration. */
 @SearchIndexable(forTarget = SearchIndexable.ALL & ~SearchIndexable.ARC)
-public class VibrationSettings extends DashboardFragment {
+public class VibrationSettings extends DashboardFragment
+        implements Preference.OnPreferenceChangeListener {
 
     private static final String TAG = "VibrationSettings";
+
+    private static final String SCROLL_FLING_HAPTIC_FEEDBACK = "scroll_fling_haptic_feedback";
+
+    private SystemSettingSwitchPreference mScrollFlingHapticFeedback;
 
     private static int getVibrationXmlResourceId(Context context) {
         if (Flags.separateAccessibilityVibrationSettingsFragments()) {
@@ -54,6 +66,29 @@ public class VibrationSettings extends DashboardFragment {
                 ? R.xml.accessibility_vibration_intensity_settings
                 : R.xml.accessibility_vibration_settings;
 
+    }
+
+    public String getLauncherPackage() {
+        Intent intent = new Intent("android.intent.action.MAIN");
+        intent.addCategory("android.intent.category.HOME");
+        return getContext().getPackageManager().resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY)
+                    .activityInfo.packageName;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mScrollFlingHapticFeedback = (SystemSettingSwitchPreference) findPreference(SCROLL_FLING_HAPTIC_FEEDBACK);
+        mScrollFlingHapticFeedback.setOnPreferenceChangeListener(this);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        if (preference == mScrollFlingHapticFeedback) {
+            EvolutionUtils.restartApp(getLauncherPackage(), getActivity());
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/src/com/android/settings/applications/RunningServices.java
+++ b/src/com/android/settings/applications/RunningServices.java
@@ -110,6 +110,12 @@ public class RunningServices extends SettingsPreferenceFragment {
         boolean showingBackground = mRunningProcessesView.mAdapter.getShowBackground();
         mOptionsMenu.findItem(SHOW_RUNNING_SERVICES).setVisible(showingBackground);
         mOptionsMenu.findItem(SHOW_BACKGROUND_PROCESSES).setVisible(!showingBackground);
+
+        if (!showingBackground) {
+            getActivity().setTitle(com.android.settingslib.R.string.runningservices_settings_title);
+        } else {
+            getActivity().setTitle(R.string.background_processes_settings_title);
+        }
     }
 
     @Override

--- a/src/com/android/settings/applications/appcompat/UserAspectRatioAppsPreferenceController.java
+++ b/src/com/android/settings/applications/appcompat/UserAspectRatioAppsPreferenceController.java
@@ -18,6 +18,8 @@ package com.android.settings.applications.appcompat;
 
 import android.content.Context;
 import android.os.Build;
+import android.os.SystemProperties;
+import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 
@@ -43,6 +45,10 @@ public class UserAspectRatioAppsPreferenceController extends BasePreferenceContr
 
     @Override
     public CharSequence getSummary() {
-        return mContext.getResources().getString(R.string.aspect_ratio_summary_text, Build.MODEL);
+        String device = SystemProperties.get("ro.product.marketname");
+        if (!TextUtils.isEmpty(device)) {
+            device = Build.MODEL;
+        }
+        return mContext.getResources().getString(R.string.aspect_ratio_summary_text, device);
     }
 }

--- a/src/com/android/settings/biometrics/fingerprint/FingerprintSettings.java
+++ b/src/com/android/settings/biometrics/fingerprint/FingerprintSettings.java
@@ -253,6 +253,7 @@ public class FingerprintSettings extends SubSettings {
         private PreferenceCategory mFingerprintUnlockCategory;
         private PreferenceCategory mFingerprintUnlockFooter;
         private boolean mFingerprintWakeAndUnlock;
+        private boolean mProximityCheckOnFingerprintUnlock;
 
         private FingerprintManager mFingerprintManager;
         private FingerprintUpdater mFingerprintUpdater;
@@ -426,6 +427,8 @@ public class FingerprintSettings extends SubSettings {
             mSensorProperties = mFingerprintManager.getSensorPropertiesInternal();
             mFingerprintWakeAndUnlock = getContext().getResources().getBoolean(
                     com.android.internal.R.bool.config_fingerprintWakeAndUnlock);
+            mProximityCheckOnFingerprintUnlock = getContext().getResources().getBoolean(
+                    com.android.internal.R.bool.config_proximityCheckOnFpsUnlock);
 
             mToken = getIntent().getByteArrayExtra(
                     ChooseLockSettingsHelper.EXTRA_KEY_CHALLENGE_TOKEN);
@@ -689,6 +692,10 @@ public class FingerprintSettings extends SubSettings {
                         mRequireScreenOnToAuthPreferenceController.setChecked(!isChecked);
                         return true;
                     });
+            if (mProximityCheckOnFingerprintUnlock) {
+                mRequireScreenOnToAuthPreference.setSummary(R.string.
+                        security_settings_require_screen_on_to_auth_with_proximity_description);
+            }
         }
 
         private void updateAddPreference() {

--- a/src/com/android/settings/biometrics/fingerprint/FingerprintSettings.java
+++ b/src/com/android/settings/biometrics/fingerprint/FingerprintSettings.java
@@ -494,10 +494,17 @@ public class FingerprintSettings extends SubSettings {
         private void updateFooterColumns(@NonNull Activity activity) {
             final EnforcedAdmin admin = RestrictedLockUtilsInternal.checkIfKeyguardFeaturesDisabled(
                     activity, DevicePolicyManager.KEYGUARD_DISABLE_FINGERPRINT, mUserId);
-            final Intent helpIntent = HelpUtils.getHelpIntent(
-                    activity, getString(getHelpResource()), activity.getClass().getName());
-            final View.OnClickListener learnMoreClickListener = (v) ->
-                    activity.startActivityForResult(helpIntent, 0);
+            final Intent helpIntent;
+            final View.OnClickListener learnMoreClickListener;
+            if (getHelpResource() != 0) {
+                helpIntent = HelpUtils.getHelpIntent(
+                        activity, getString(getHelpResource()), activity.getClass().getName());
+                learnMoreClickListener = (v) ->
+                        activity.startActivityForResult(helpIntent, 0);
+            } else {
+                helpIntent = null;
+                learnMoreClickListener = null;
+            }
 
             mFooterColumns.clear();
             if (admin != null) {
@@ -519,20 +526,24 @@ public class FingerprintSettings extends SubSettings {
                 column2.mTitle = getText(
                         R.string.security_fingerprint_disclaimer_lockscreen_disabled_2
                 );
-                if (isSfps()) {
-                    column2.mLearnMoreOverrideText = getText(
-                            R.string.security_settings_fingerprint_settings_footer_learn_more);
+                if (helpIntent != null) {
+                    if (!isUdfps() && mFingerprintWakeAndUnlock) {
+                        column2.mLearnMoreOverrideText = getText(
+                                R.string.security_settings_fingerprint_settings_footer_learn_more);
+                    }
+                    column2.mLearnMoreClickListener = learnMoreClickListener;
                 }
-                column2.mLearnMoreClickListener = learnMoreClickListener;
                 mFooterColumns.add(column2);
             } else {
                 final FooterColumn column = new FooterColumn();
                 column.mTitle = getString(
                         R.string.security_settings_fingerprint_enroll_introduction_v3_message,
                         DeviceHelper.getDeviceName(getActivity()));
-                column.mLearnMoreClickListener = learnMoreClickListener;
-                column.mLearnMoreOverrideText = getText(
-                        R.string.security_settings_fingerprint_settings_footer_learn_more);
+                if (helpIntent != null) {
+                    column.mLearnMoreClickListener = learnMoreClickListener;
+                    column.mLearnMoreOverrideText = getText(
+                            R.string.security_settings_fingerprint_settings_footer_learn_more);
+                }
                 mFooterColumns.add(column);
             }
         }

--- a/src/com/android/settings/core/gateway/SettingsGateway.java
+++ b/src/com/android/settings/core/gateway/SettingsGateway.java
@@ -104,6 +104,7 @@ import com.android.settings.display.AutoBrightnessSettings;
 import com.android.settings.display.DcDimmingSettings;
 import com.android.settings.display.NightDisplaySettings;
 import com.android.settings.display.ScreenTimeoutSettings;
+import com.android.settings.display.RefreshRateSettings;
 import com.android.settings.display.SmartAutoRotatePreferenceFragment;
 import com.android.settings.display.SmartPixels;
 import com.android.settings.display.darkmode.DarkModeSettingsFragment;
@@ -338,6 +339,7 @@ public class SettingsGateway {
             ResetDashboardFragment.class.getName(),
             NightDisplaySettings.class.getName(),
             DcDimmingSettings.class.getName(),
+            RefreshRateSettings.class.getName(),
             ManageDomainUrls.class.getName(),
             AutomaticStorageManagerSettings.class.getName(),
             StorageDashboardFragment.class.getName(),

--- a/src/com/android/settings/core/gateway/SettingsGateway.java
+++ b/src/com/android/settings/core/gateway/SettingsGateway.java
@@ -178,6 +178,7 @@ import com.android.settings.security.SecurityAdvancedSettings;
 import com.android.settings.security.SecuritySettings;
 import com.android.settings.shortcut.CreateShortcut;
 import com.android.settings.sound.MediaControlsSettings;
+import com.android.settings.sound.VolumeSteps;
 import com.android.settings.support.SupportDashboardActivity;
 import com.android.settings.system.ResetDashboardFragment;
 import com.android.settings.system.SystemDashboardFragment;
@@ -391,6 +392,7 @@ public class SettingsGateway {
             SmartPixels.class.getName(),
             SleepMode.class.getName(),
             WirelessDebuggingFragment.class.getName(),
+            VolumeSteps.class.getName(),
             RunningServices.class.getName()
     };
 

--- a/src/com/android/settings/core/gateway/SettingsGateway.java
+++ b/src/com/android/settings/core/gateway/SettingsGateway.java
@@ -99,6 +99,7 @@ import com.android.settings.deviceinfo.batteryinfo.BatteryInfoFragment;
 import com.android.settings.deviceinfo.firmwareversion.FirmwareVersionSettings;
 import com.android.settings.deviceinfo.legal.ModuleLicensesDashboard;
 import com.android.settings.display.AutoBrightnessSettings;
+import com.android.settings.display.DcDimmingSettings;
 import com.android.settings.display.NightDisplaySettings;
 import com.android.settings.display.ScreenTimeoutSettings;
 import com.android.settings.display.SmartAutoRotatePreferenceFragment;
@@ -333,6 +334,7 @@ public class SettingsGateway {
             MainClearConfirm.class.getName(),
             ResetDashboardFragment.class.getName(),
             NightDisplaySettings.class.getName(),
+            DcDimmingSettings.class.getName(),
             ManageDomainUrls.class.getName(),
             AutomaticStorageManagerSettings.class.getName(),
             StorageDashboardFragment.class.getName(),

--- a/src/com/android/settings/core/gateway/SettingsGateway.java
+++ b/src/com/android/settings/core/gateway/SettingsGateway.java
@@ -40,6 +40,7 @@ import com.android.settings.accounts.ManagedProfileSettings;
 import com.android.settings.applications.AppDashboardFragment;
 import com.android.settings.applications.ProcessStatsSummary;
 import com.android.settings.applications.ProcessStatsUi;
+import com.android.settings.applications.RunningServices;
 import com.android.settings.applications.UsageAccessDetails;
 import com.android.settings.applications.appcompat.UserAspectRatioDetails;
 import com.android.settings.applications.appinfo.AlarmsAndRemindersDetails;
@@ -389,7 +390,8 @@ public class SettingsGateway {
             LiveDisplaySettings.class.getName(),
             SmartPixels.class.getName(),
             SleepMode.class.getName(),
-            WirelessDebuggingFragment.class.getName()
+            WirelessDebuggingFragment.class.getName(),
+            RunningServices.class.getName()
     };
 
     public static final String[] SETTINGS_FOR_RESTRICTED = {
@@ -441,5 +443,6 @@ public class SettingsGateway {
             Settings.SmartPixelsActivity.class.getName(),
             Settings.SleepModeActivity.class.getName(),
             Settings.WirelessDebuggingActivity.class.getName(),
+            Settings.DevRunningServicesActivity.class.getName(),
     };
 }

--- a/src/com/android/settings/core/gateway/SettingsGateway.java
+++ b/src/com/android/settings/core/gateway/SettingsGateway.java
@@ -105,6 +105,7 @@ import com.android.settings.display.DcDimmingSettings;
 import com.android.settings.display.NightDisplaySettings;
 import com.android.settings.display.ScreenTimeoutSettings;
 import com.android.settings.display.SmartAutoRotatePreferenceFragment;
+import com.android.settings.display.SmartPixels;
 import com.android.settings.display.darkmode.DarkModeSettingsFragment;
 import com.android.settings.dream.DreamSettings;
 import com.android.settings.enterprise.EnterprisePrivacySettings;
@@ -200,7 +201,6 @@ import com.android.settings.wifi.tether.WifiTetherSettings;
 
 import com.evolution.settings.EvolutionSettings;
 import com.evolution.settings.fragments.HeadsUpSettings;
-import com.evolution.settings.fragments.SmartPixels;
 
 import ink.kscope.settings.wifi.tether.WifiTetherClientManager;
 

--- a/src/com/android/settings/core/gateway/SettingsGateway.java
+++ b/src/com/android/settings/core/gateway/SettingsGateway.java
@@ -91,6 +91,7 @@ import com.android.settings.datausage.DataUsageSummary;
 import com.android.settings.datetime.DateTimeSettings;
 import com.android.settings.deletionhelper.AutomaticStorageManagerSettings;
 import com.android.settings.development.DevelopmentSettingsDashboardFragment;
+import com.android.settings.development.WirelessDebuggingFragment;
 import com.android.settings.deviceinfo.PrivateVolumeForget;
 import com.android.settings.deviceinfo.PublicVolumeSettings;
 import com.android.settings.deviceinfo.StorageDashboardFragment;
@@ -387,7 +388,8 @@ public class SettingsGateway {
             WifiTetherClientManager.class.getName(),
             LiveDisplaySettings.class.getName(),
             SmartPixels.class.getName(),
-            SleepMode.class.getName()
+            SleepMode.class.getName(),
+            WirelessDebuggingFragment.class.getName()
     };
 
     public static final String[] SETTINGS_FOR_RESTRICTED = {
@@ -438,5 +440,6 @@ public class SettingsGateway {
             Settings.HeadsUpSettingsActivity.class.getName(),
             Settings.SmartPixelsActivity.class.getName(),
             Settings.SleepModeActivity.class.getName(),
+            Settings.WirelessDebuggingActivity.class.getName(),
     };
 }

--- a/src/com/android/settings/development/AdbRootPreferenceController.java
+++ b/src/com/android/settings/development/AdbRootPreferenceController.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2018 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.development;
+
+import android.adb.ADBRootService;
+import android.content.Context;
+import android.os.UserManager;
+
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.SwitchPreference;
+
+import com.android.settings.R;
+import com.android.settings.core.PreferenceControllerMixin;
+import com.android.settingslib.development.DeveloperOptionsPreferenceController;
+
+public class AdbRootPreferenceController extends DeveloperOptionsPreferenceController
+        implements Preference.OnPreferenceChangeListener, PreferenceControllerMixin {
+
+    private static final String TAG = "AdbRootPreferenceController";
+    private static final String PREF_KEY = "enable_adb_root";
+
+    private final ADBRootService mADBRootService;
+
+    public AdbRootPreferenceController(Context context,
+            DevelopmentSettingsDashboardFragment fragment) {
+        super(context);
+
+        mADBRootService = new ADBRootService();
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return PREF_KEY;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return mADBRootService.isSupported();
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+
+        ((SwitchPreference) mPreference).setChecked(mADBRootService.getEnabled());
+
+        if (!isAdminUser()) {
+            mPreference.setEnabled(false);
+        }
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        final boolean rootEnabled = (Boolean) newValue;
+        mADBRootService.setEnabled(rootEnabled);
+        return true;
+    }
+
+    @Override
+    protected void onDeveloperOptionsSwitchEnabled() {
+        if (isAdminUser()) {
+            mPreference.setEnabled(true);
+        }
+    }
+
+    boolean isAdminUser() {
+        return ((UserManager) mContext.getSystemService(Context.USER_SERVICE)).isAdminUser();
+    }
+}

--- a/src/com/android/settings/development/AdbRootPreferenceController.java
+++ b/src/com/android/settings/development/AdbRootPreferenceController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 The LineageOS Project
+ * Copyright (C) 2018-2024 The LineageOS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,6 +70,14 @@ public class AdbRootPreferenceController extends DeveloperOptionsPreferenceContr
         final boolean rootEnabled = (Boolean) newValue;
         mADBRootService.setEnabled(rootEnabled);
         return true;
+    }
+
+    @Override
+    protected void onDeveloperOptionsSwitchDisabled() {
+        super.onDeveloperOptionsSwitchDisabled();
+
+        mADBRootService.setEnabled(false);
+        ((SwitchPreferenceCompat) mPreference).setChecked(false);
     }
 
     @Override

--- a/src/com/android/settings/development/AdbRootPreferenceController.java
+++ b/src/com/android/settings/development/AdbRootPreferenceController.java
@@ -22,7 +22,8 @@ import android.os.UserManager;
 
 import androidx.preference.Preference;
 import androidx.preference.PreferenceScreen;
-import androidx.preference.SwitchPreference;
+import androidx.preference.SwitchPreferenceCompat;
+import androidx.preference.TwoStatePreference;
 
 import com.android.settings.R;
 import com.android.settings.core.PreferenceControllerMixin;
@@ -57,7 +58,7 @@ public class AdbRootPreferenceController extends DeveloperOptionsPreferenceContr
     public void displayPreference(PreferenceScreen screen) {
         super.displayPreference(screen);
 
-        ((SwitchPreference) mPreference).setChecked(mADBRootService.getEnabled());
+        ((TwoStatePreference) mPreference).setChecked(mADBRootService.getEnabled());
 
         if (!isAdminUser()) {
             mPreference.setEnabled(false);

--- a/src/com/android/settings/development/DevelopmentSettingsDashboardFragment.java
+++ b/src/com/android/settings/development/DevelopmentSettingsDashboardFragment.java
@@ -631,6 +631,7 @@ public class DevelopmentSettingsDashboardFragment extends RestrictedDashboardFra
         controllers.add(new CoolColorTemperaturePreferenceController(context));
         controllers.add(new SelectDSUPreferenceController(context));
         controllers.add(new AdbPreferenceController(context, fragment));
+        controllers.add(new AdbRootPreferenceController(context, fragment));
         controllers.add(new ClearAdbKeysPreferenceController(context, fragment));
         controllers.add(new WirelessDebuggingPreferenceController(context, lifecycle));
         controllers.add(new AdbAuthorizationTimeoutPreferenceController(context));

--- a/src/com/android/settings/development/DevelopmentSettingsDashboardFragment.java
+++ b/src/com/android/settings/development/DevelopmentSettingsDashboardFragment.java
@@ -613,8 +613,8 @@ public class DevelopmentSettingsDashboardFragment extends RestrictedDashboardFra
             @Nullable BluetoothA2dpConfigStore bluetoothA2dpConfigStore) {
         final List<AbstractPreferenceController> controllers = new ArrayList<>();
         controllers.add(new MemoryUsagePreferenceController(context));
-        controllers.add(new BugReportPreferenceController(context));
-        controllers.add(new BugReportHandlerPreferenceController(context));
+        //controllers.add(new BugReportPreferenceController(context));
+        //controllers.add(new BugReportHandlerPreferenceController(context));
         controllers.add(new SystemServerHeapDumpPreferenceController(context));
         controllers.add(new DevelopmentMemtagPagePreferenceController(context, fragment));
         controllers.add(new LocalBackupPasswordPreferenceController(context));
@@ -635,7 +635,7 @@ public class DevelopmentSettingsDashboardFragment extends RestrictedDashboardFra
         controllers.add(new WirelessDebuggingPreferenceController(context, lifecycle));
         controllers.add(new AdbAuthorizationTimeoutPreferenceController(context));
         controllers.add(new LocalTerminalPreferenceController(context));
-        controllers.add(new BugReportInPowerPreferenceController(context));
+        //controllers.add(new BugReportInPowerPreferenceController(context));
         controllers.add(new AutomaticSystemServerHeapDumpPreferenceController(context));
         controllers.add(new MockLocationAppPreferenceController(context, fragment));
         controllers.add(new MockModemPreferenceController(context));

--- a/src/com/android/settings/development/DevelopmentSettingsDashboardFragment.java
+++ b/src/com/android/settings/development/DevelopmentSettingsDashboardFragment.java
@@ -631,9 +631,9 @@ public class DevelopmentSettingsDashboardFragment extends RestrictedDashboardFra
         controllers.add(new CoolColorTemperaturePreferenceController(context));
         controllers.add(new SelectDSUPreferenceController(context));
         controllers.add(new AdbPreferenceController(context, fragment));
-        controllers.add(new AdbRootPreferenceController(context, fragment));
         controllers.add(new ClearAdbKeysPreferenceController(context, fragment));
         controllers.add(new WirelessDebuggingPreferenceController(context, lifecycle));
+        controllers.add(new AdbRootPreferenceController(context, fragment));
         controllers.add(new AdbAuthorizationTimeoutPreferenceController(context));
         controllers.add(new LocalTerminalPreferenceController(context));
         //controllers.add(new BugReportInPowerPreferenceController(context));

--- a/src/com/android/settings/deviceinfo/batteryinfo/BatteryDesignCapacityPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/batteryinfo/BatteryDesignCapacityPreferenceController.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.deviceinfo.batteryinfo;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.BatteryManager;
+
+import com.android.settings.R;
+import com.android.settings.core.BasePreferenceController;
+import com.android.settingslib.fuelgauge.BatteryUtils;
+
+/**
+ * A controller that manages the information about battery design capacity.
+ */
+public class BatteryDesignCapacityPreferenceController extends BasePreferenceController {
+
+    public BatteryDesignCapacityPreferenceController(Context context, String preferenceKey) {
+        super(context, preferenceKey);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return AVAILABLE;
+    }
+
+    @Override
+    public CharSequence getSummary() {
+        Intent batteryIntent = BatteryUtils.getBatteryIntent(mContext);
+        final int designCapacityUah =
+                batteryIntent.getIntExtra(BatteryManager.EXTRA_DESIGN_CAPACITY, -1);
+
+        if (designCapacityUah != -1) {
+            int designCapacity = designCapacityUah / 1_000;
+            return mContext.getString(R.string.battery_design_capacity_summary, designCapacity);
+        }
+
+        return mContext.getString(R.string.battery_design_capacity_not_available);
+    }
+}

--- a/src/com/android/settings/deviceinfo/batteryinfo/BatteryHealthPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/batteryinfo/BatteryHealthPreferenceController.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.deviceinfo.batteryinfo;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.BatteryManager;
+
+import com.android.settings.R;
+import com.android.settings.core.BasePreferenceController;
+import com.android.settingslib.fuelgauge.BatteryUtils;
+
+/**
+ * A controller that manages the information about battery health.
+ */
+public class BatteryHealthPreferenceController extends BasePreferenceController {
+
+    public BatteryHealthPreferenceController(Context context, String preferenceKey) {
+        super(context, preferenceKey);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return AVAILABLE;
+    }
+
+    @Override
+    public CharSequence getSummary() {
+        final Intent batteryIntent = BatteryUtils.getBatteryIntent(mContext);
+        final int health =
+                batteryIntent.getIntExtra(
+                        BatteryManager.EXTRA_HEALTH, BatteryManager.BATTERY_HEALTH_UNKNOWN);
+
+        switch (health) {
+            case BatteryManager.BATTERY_HEALTH_GOOD:
+                return mContext.getString(R.string.battery_health_good);
+            case BatteryManager.BATTERY_HEALTH_OVERHEAT:
+                return mContext.getString(R.string.battery_health_overheat);
+            case BatteryManager.BATTERY_HEALTH_DEAD:
+                return mContext.getString(R.string.battery_health_dead);
+            case BatteryManager.BATTERY_HEALTH_OVER_VOLTAGE:
+                return mContext.getString(R.string.battery_health_over_voltage);
+            case BatteryManager.BATTERY_HEALTH_UNSPECIFIED_FAILURE:
+                return mContext.getString(R.string.battery_health_unspecified_failure);
+            case BatteryManager.BATTERY_HEALTH_COLD:
+                return mContext.getString(R.string.battery_health_cold);
+            default:
+                return mContext.getString(R.string.battery_health_unknown);
+        }
+    }
+}

--- a/src/com/android/settings/deviceinfo/batteryinfo/BatteryMaximumCapacityPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/batteryinfo/BatteryMaximumCapacityPreferenceController.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.deviceinfo.batteryinfo;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.BatteryManager;
+
+import com.android.settings.R;
+import com.android.settings.core.BasePreferenceController;
+import com.android.settingslib.fuelgauge.BatteryUtils;
+
+/**
+ * A controller that manages the information about battery maximum capacity.
+ */
+public class BatteryMaximumCapacityPreferenceController extends BasePreferenceController {
+
+    public BatteryMaximumCapacityPreferenceController(Context context, String preferenceKey) {
+        super(context, preferenceKey);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return AVAILABLE;
+    }
+
+    @Override
+    public CharSequence getSummary() {
+        Intent batteryIntent = BatteryUtils.getBatteryIntent(mContext);
+        final int maxCapacityUah =
+                batteryIntent.getIntExtra(BatteryManager.EXTRA_MAXIMUM_CAPACITY, 0);
+        final int designCapacityUah =
+                batteryIntent.getIntExtra(BatteryManager.EXTRA_DESIGN_CAPACITY, 0);
+
+        if (maxCapacityUah != 0 && designCapacityUah != 0) {
+            int maxCapacity = maxCapacityUah / 1_000;
+            int designCapacity = designCapacityUah / 1_000;
+            int percentage = (maxCapacity * 100) / designCapacity;
+
+            return mContext.getString(
+                    R.string.battery_maximum_capacity_summary, maxCapacity, percentage);
+        }
+
+        return mContext.getString(R.string.battery_maximum_capacity_not_available);
+    }
+}

--- a/src/com/android/settings/deviceinfo/batteryinfo/BatteryTechnologyPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/batteryinfo/BatteryTechnologyPreferenceController.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.deviceinfo.batteryinfo;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.BatteryManager;
+
+import com.android.settings.R;
+import com.android.settings.core.BasePreferenceController;
+import com.android.settingslib.fuelgauge.BatteryUtils;
+
+/**
+ * A controller that manages the information about battery technology.
+ */
+public class BatteryTechnologyPreferenceController extends BasePreferenceController {
+
+    public BatteryTechnologyPreferenceController(Context context, String preferenceKey) {
+        super(context, preferenceKey);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return AVAILABLE;
+    }
+
+    @Override
+    public CharSequence getSummary() {
+        final Intent batteryIntent = BatteryUtils.getBatteryIntent(mContext);
+        final String technology = batteryIntent.getStringExtra(BatteryManager.EXTRA_TECHNOLOGY);
+
+        return technology != null
+                ? technology
+                : mContext.getText(R.string.battery_technology_not_available);
+    }
+}

--- a/src/com/android/settings/deviceinfo/batteryinfo/BatteryTemperaturePreferenceController.java
+++ b/src/com/android/settings/deviceinfo/batteryinfo/BatteryTemperaturePreferenceController.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.deviceinfo.batteryinfo;
+
+import android.content.Context;
+import android.content.Intent;
+import android.icu.text.MeasureFormat;
+import android.icu.util.Measure;
+import android.icu.util.MeasureUnit;
+import android.os.BatteryManager;
+
+import com.android.settings.R;
+import com.android.settings.core.BasePreferenceController;
+import com.android.settingslib.fuelgauge.BatteryUtils;
+
+import java.util.Locale;
+
+/**
+ * A controller that manages the information about battery temperature.
+ */
+public class BatteryTemperaturePreferenceController extends BasePreferenceController {
+
+    public BatteryTemperaturePreferenceController(Context context, String preferenceKey) {
+        super(context, preferenceKey);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return AVAILABLE;
+    }
+
+    @Override
+    public CharSequence getSummary() {
+        final Intent batteryIntent = BatteryUtils.getBatteryIntent(mContext);
+        final int temperatureTenths =
+                batteryIntent.getIntExtra(BatteryManager.EXTRA_TEMPERATURE, -1);
+
+        if (temperatureTenths != -1) {
+            float temperature = temperatureTenths / 10f;
+
+            return MeasureFormat.getInstance(Locale.getDefault(), MeasureFormat.FormatWidth.SHORT)
+                    .format(new Measure(temperature, MeasureUnit.CELSIUS));
+        }
+
+        return mContext.getText(R.string.battery_temperature_not_available);
+    }
+}

--- a/src/com/android/settings/deviceinfo/batteryinfo/BatteryVoltagePreferenceController.java
+++ b/src/com/android/settings/deviceinfo/batteryinfo/BatteryVoltagePreferenceController.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.deviceinfo.batteryinfo;
+
+import android.content.Context;
+import android.content.Intent;
+import android.icu.text.MeasureFormat;
+import android.icu.util.Measure;
+import android.icu.util.MeasureUnit;
+import android.os.BatteryManager;
+
+import com.android.settings.R;
+import com.android.settings.core.BasePreferenceController;
+import com.android.settingslib.fuelgauge.BatteryUtils;
+
+import java.util.Locale;
+
+/**
+ * A controller that manages the information about battery voltage.
+ */
+public class BatteryVoltagePreferenceController extends BasePreferenceController {
+
+    public BatteryVoltagePreferenceController(Context context, String preferenceKey) {
+        super(context, preferenceKey);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return AVAILABLE;
+    }
+
+    @Override
+    public CharSequence getSummary() {
+        final Intent batteryIntent = BatteryUtils.getBatteryIntent(mContext);
+        final int voltageMillivolts = batteryIntent.getIntExtra(BatteryManager.EXTRA_VOLTAGE, -1);
+
+        if (voltageMillivolts != -1) {
+            float voltage = voltageMillivolts / 1_000f;
+
+            return MeasureFormat.getInstance(Locale.getDefault(), MeasureFormat.FormatWidth.SHORT)
+                    .format(new Measure(voltage, MeasureUnit.VOLT));
+        }
+
+        return mContext.getText(R.string.battery_voltage_not_available);
+    }
+}

--- a/src/com/android/settings/deviceinfo/imei/ImeiInfoPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/imei/ImeiInfoPreferenceController.java
@@ -114,13 +114,11 @@ public class ImeiInfoPreferenceController extends BasePreferenceController {
 
     @Override
     public CharSequence getSummary() {
-        return mContext.getString(R.string.device_info_protected_single_press);
+        return getSummary(0);
     }
 
     private CharSequence getSummary(int simSlot) {
-        final int phoneType = getPhoneType(simSlot);
-        return phoneType == PHONE_TYPE_CDMA ? mTelephonyManager.getMeid(simSlot)
-                : mTelephonyManager.getImei(simSlot);
+        return mContext.getString(R.string.device_info_protected_single_press);
     }
 
     @Override
@@ -131,7 +129,6 @@ public class ImeiInfoPreferenceController extends BasePreferenceController {
         }
 
         ImeiInfoDialogFragment.show(mFragment, simSlot, preference.getTitle().toString());
-        preference.setSummary(getSummary(simSlot));
         return true;
     }
 
@@ -151,7 +148,7 @@ public class ImeiInfoPreferenceController extends BasePreferenceController {
     @VisibleForTesting
     protected void updatePreference(Preference preference, int simSlot) {
         preference.setTitle(getTitle(simSlot));
-        preference.setSummary(getSummary());
+        preference.setSummary(getSummary(simSlot));
     }
 
     private CharSequence getTitleForGsmPhone(int simSlot, boolean isPrimaryImei) {

--- a/src/com/android/settings/display/AutoRotatePreferenceController.java
+++ b/src/com/android/settings/display/AutoRotatePreferenceController.java
@@ -18,6 +18,7 @@ import android.content.Context;
 import android.text.TextUtils;
 
 import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
 
 import com.android.internal.view.RotationPolicy;
 import com.android.settings.R;
@@ -29,12 +30,17 @@ import com.android.settingslib.core.lifecycle.LifecycleObserver;
 import com.android.settingslib.core.lifecycle.events.OnPause;
 import com.android.settingslib.core.lifecycle.events.OnResume;
 
+import com.evolution.settings.preference.SystemSettingSwitchPreference;
+
 public class AutoRotatePreferenceController extends TogglePreferenceController implements
         PreferenceControllerMixin, Preference.OnPreferenceChangeListener, LifecycleObserver,
         OnResume, OnPause {
 
+    private final String FLOATING_BUTTON_PREF_KEY = "enable_floating_rotation_button";
+
     private final MetricsFeatureProvider mMetricsFeatureProvider;
     private Preference mPreference;
+    private SystemSettingSwitchPreference mFloatingPref;
     private RotationPolicy.RotationPolicyListener mRotationPolicyListener;
 
     public AutoRotatePreferenceController(Context context, String key) {
@@ -43,8 +49,15 @@ public class AutoRotatePreferenceController extends TogglePreferenceController i
     }
 
     @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+        mFloatingPref = screen.findPreference(FLOATING_BUTTON_PREF_KEY);
+    }
+
+    @Override
     public void updateState(Preference preference) {
         mPreference = preference;
+        if (mFloatingPref != null) mFloatingPref.setEnabled(!isChecked());
         super.updateState(preference);
     }
 
@@ -105,6 +118,7 @@ public class AutoRotatePreferenceController extends TogglePreferenceController i
                 isLocked);
         RotationPolicy.setRotationLock(mContext, isLocked,
                 /* caller= */ "AutoRotatePreferenceController#setChecked");
+        if (mFloatingPref != null) mFloatingPref.setEnabled(!isChecked);
         return true;
     }
 }

--- a/src/com/android/settings/display/CustomScreenResolutionController.java
+++ b/src/com/android/settings/display/CustomScreenResolutionController.java
@@ -43,7 +43,7 @@ public class CustomScreenResolutionController extends BasePreferenceController i
         Preference.OnPreferenceChangeListener {
     private static final String KEY_RESOLUTION_SWITCH = "custom_screen_resolution";
     private static final String TAG = "customScreenResolution";
-    private static final String RESOLUTION_METRIC_SETTING_KEY = "user_selected_custom_resolution";
+    private static final String RESOLUTION_METRIC_SETTING_KEY = "user_selected_resolution";
 
     private ListPreference mListPreference;
 

--- a/src/com/android/settings/display/CustomScreenResolutionController.java
+++ b/src/com/android/settings/display/CustomScreenResolutionController.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ * Copyright (C) 2022 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import android.annotation.Nullable;
+import android.util.Log;
+import android.content.Context;
+import android.hardware.display.DisplayManager;
+import android.provider.Settings;
+import android.view.Display;
+
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+
+import com.android.settings.R;
+import com.android.settingslib.display.DisplayDensityUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.android.settings.core.BasePreferenceController;
+
+/** Controller that switch the screen resolution. */
+public class CustomScreenResolutionController extends BasePreferenceController implements
+        Preference.OnPreferenceChangeListener {
+    private static final String KEY_RESOLUTION_SWITCH = "custom_screen_resolution";
+    private static final String TAG = "customScreenResolution";
+    private static final String RESOLUTION_METRIC_SETTING_KEY = "user_selected_custom_resolution";
+
+    private ListPreference mListPreference;
+
+    private final List<String> mEntries = new ArrayList<>();
+    private final List<String> mValues = new ArrayList<>();
+
+    private final Display mDisplay;
+    private final DisplayObserver mDisplayObserver;
+
+    public CustomScreenResolutionController(Context context) {
+        super(context, KEY_RESOLUTION_SWITCH);
+        mDisplay = Objects.requireNonNull(
+                context.getSystemService(DisplayManager.class)).getDisplay(Display.DEFAULT_DISPLAY);
+
+        mDisplayObserver = new DisplayObserver(context);
+
+        // Find related display resolutions
+        Display.Mode mode = mDisplay.getMode();
+        Display.Mode[] avail_modes = mDisplay.getSupportedModes();
+
+        if (context.getResources().getBoolean(R.bool.config_show_custom_screen_resolution_switch)) {
+            for (Display.Mode m : avail_modes) {
+                if (m.getRefreshRate() == mode.getRefreshRate()) {
+                    mEntries.add(
+                            String.format("%d x %d", m.getPhysicalWidth(), m.getPhysicalHeight()));
+                    mValues.add(String.format("%d %d", m.getPhysicalWidth(),
+                            m.getPhysicalHeight()));
+                }
+            }
+        }
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return mEntries.size() > 1 ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return KEY_RESOLUTION_SWITCH;
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        mListPreference = screen.findPreference(getPreferenceKey());
+        assert mListPreference != null;
+        mListPreference.setEntries(mEntries.toArray(new String[0]));
+        mListPreference.setEntryValues(mValues.toArray(new String[0]));
+
+        super.displayPreference(screen);
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        Display.Mode mode = mDisplay.getMode();
+
+        int index = Math.max(0, mListPreference.findIndexOfValue(
+                String.format("%d %d", mode.getPhysicalWidth(), mode.getPhysicalHeight())));
+        mListPreference.setValueIndex(index);
+        mListPreference.setSummary(mListPreference.getEntries()[index]);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        mDisplayObserver.startObserve();
+
+        // Set display resolution here
+        String[] valueString = newValue.toString().split(" ");
+        assert valueString.length == 2;
+        int resolutionWidth = Integer.parseInt(valueString[0]);
+        int resolutionHeight = Integer.parseInt(valueString[1]);
+        Display.Mode switchMode = new Display.Mode(resolutionWidth, resolutionHeight,
+                mDisplay.getMode().getRefreshRate());
+
+        /** For store settings globally. */
+        /** TODO(b/238061217): Moving to an atom with the same string */
+        Settings.System.putString(
+                mContext.getContentResolver(),
+                RESOLUTION_METRIC_SETTING_KEY,
+                switchMode.getPhysicalWidth()
+                        + "x"
+                        + switchMode.getPhysicalHeight());
+
+        mDisplay.setUserPreferredDisplayMode(switchMode);
+        return true;
+    }
+
+    private static final class DisplayObserver implements DisplayManager.DisplayListener {
+        @Nullable
+        private final Context mContext;
+        private final AtomicInteger mOldDensity = new AtomicInteger(-1);
+        private final AtomicInteger mPreviousWidth = new AtomicInteger(-1);
+
+        DisplayObserver(Context context) {
+            mContext = context;
+        }
+
+        public void startObserve() {
+            // Here, we record the initial screen density and width for future use
+            if (mContext == null) {
+                return;
+            }
+            final DisplayDensityUtils density = new DisplayDensityUtils(mContext);
+            mOldDensity.set(density.getDefaultDisplayDensityValues()[density.getCurrentIndexForDefaultDisplay()]);
+            mPreviousWidth.set(getCurrentWidth());
+
+            // Register itself as a display listener
+            final DisplayManager dm = mContext.getSystemService(DisplayManager.class);
+            assert dm != null;
+            dm.registerDisplayListener(this, null);
+        }
+
+        public void stopObserve() {
+            if (mContext == null) {
+                return;
+            }
+
+            final DisplayManager dm = mContext.getSystemService(DisplayManager.class);
+            assert dm != null;
+            dm.unregisterDisplayListener(this);
+        }
+
+        @Override
+        public void onDisplayAdded(int displayId) {
+        }
+
+        @Override
+        public void onDisplayRemoved(int displayId) {
+        }
+
+        @Override
+        public void onDisplayChanged(int displayId) {
+            if (displayId != Display.DEFAULT_DISPLAY) {
+                return;
+            }
+            if (!isResolutionChangeApplied(displayId)) {
+                return;
+            }
+            restoreDensity();
+
+            stopObserve();
+        }
+
+        public void restoreDensity() {
+            final DisplayDensityUtils density = new DisplayDensityUtils(mContext);
+
+            // Get available density values and current resolution width
+            int[] densityValues = density.getDefaultDisplayDensityValues();
+            int newWidth = getCurrentWidth();
+
+            // Scale the DPI based on the following formula:
+            //   px = C1 * (dpi / C2) ==> px_new / px_old = dpi_new / dpi_old
+            // So we have:
+            //   dpi_new = dpi_old * px_new / px_old
+            int newDensity = (int) ((double) mOldDensity.get() * newWidth / mPreviousWidth.get());
+
+            // Find the closet dpi available in density values
+            int minDistance = Math.abs(densityValues[0] - newDensity);
+            int idx = 0;
+            for (int i = 1; i < densityValues.length; i++) {
+                int dist = Math.abs(densityValues[i] - newDensity);
+                if (dist < minDistance) {
+                    minDistance = dist;
+                    idx = i;
+                }
+            }
+            Log.d(TAG, "Current width " + newWidth + ", old width " + mPreviousWidth.get());
+            Log.d(TAG,
+                    "Original dpi: " + mOldDensity + ", would like to change to " + newDensity
+                            + " actually set to " + densityValues[idx]);
+            density.setForcedDisplayDensity(idx);
+
+            // Update values
+            mPreviousWidth.set(newWidth);
+            mOldDensity.set(densityValues[idx]);
+        }
+
+        public boolean isResolutionChangeApplied(int displayId) {
+            return mPreviousWidth.get() != getCurrentWidth();
+        }
+
+        // Get the width of current resolution
+        private int getCurrentWidth() {
+            final DisplayManager dm = mContext.getSystemService(DisplayManager.class);
+            assert dm != null;
+            return dm.getDisplay(Display.DEFAULT_DISPLAY).getMode().getPhysicalWidth();
+        }
+    }
+}
+
+

--- a/src/com/android/settings/display/CustomScreenResolutionController.java
+++ b/src/com/android/settings/display/CustomScreenResolutionController.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.android.internal.util.evolution.EvolutionUtils;
+
 import com.android.settings.core.BasePreferenceController;
 
 /** Controller that switch the screen resolution. */
@@ -47,6 +49,8 @@ public class CustomScreenResolutionController extends BasePreferenceController i
 
     private ListPreference mListPreference;
 
+    private Context mContext;
+
     private final List<String> mEntries = new ArrayList<>();
     private final List<String> mValues = new ArrayList<>();
 
@@ -55,6 +59,7 @@ public class CustomScreenResolutionController extends BasePreferenceController i
 
     public CustomScreenResolutionController(Context context) {
         super(context, KEY_RESOLUTION_SWITCH);
+        mContext = context;
         mDisplay = Objects.requireNonNull(
                 context.getSystemService(DisplayManager.class)).getDisplay(Display.DEFAULT_DISPLAY);
 
@@ -128,6 +133,7 @@ public class CustomScreenResolutionController extends BasePreferenceController i
                         + switchMode.getPhysicalHeight());
 
         mDisplay.setUserPreferredDisplayMode(switchMode);
+        EvolutionUtils.restartProcess(mContext, "com.android.systemui");
         return true;
     }
 

--- a/src/com/android/settings/display/DcDimmingPreference.java
+++ b/src/com/android/settings/display/DcDimmingPreference.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2020 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import static android.hardware.display.DcDimmingManager.MODE_AUTO_OFF;
+import static android.hardware.display.DcDimmingManager.MODE_AUTO_TIME;
+
+import android.content.Context;
+import android.content.ContentResolver;
+import android.database.ContentObserver;
+import android.hardware.display.DcDimmingManager;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.UserHandle;
+import android.provider.Settings;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.Switch;
+
+import androidx.preference.PreferenceManager;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
+
+import com.android.settings.R;
+import com.android.settingslib.widget.TwoTargetPreference;
+
+public class DcDimmingPreference extends TwoTargetPreference {
+
+    private Switch mSwitch;
+    private boolean mChecked;
+    private final DcDimmingManager mDcDimmingManager;
+
+    public DcDimmingPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        mDcDimmingManager = (DcDimmingManager) context.getSystemService(Context.DC_DIM_SERVICE);
+        if (mDcDimmingManager != null && mDcDimmingManager.isAvailable()) {
+            SettingsObserver settingsObserver = new SettingsObserver(new Handler());
+            settingsObserver.observe();
+        }
+    }
+
+    @Override
+    protected int getSecondTargetResId() {
+        return R.layout.preference_widget_primary_switch;
+    }
+
+    @Override
+    protected void onAttachedToHierarchy(PreferenceManager preferenceManager) {
+        super.onAttachedToHierarchy(preferenceManager);
+        if (mDcDimmingManager == null || !mDcDimmingManager.isAvailable()) {
+            setVisible(false);
+            return;
+        }
+        boolean active = mDcDimmingManager.isDcDimmingOn();
+        setChecked(active);
+        updateSummary(active);
+    }
+
+    @Override
+    public void onBindViewHolder(PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        final View widgetView = holder.findViewById(android.R.id.widget_frame);
+        if (widgetView != null) {
+            widgetView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (mSwitch != null && !mSwitch.isEnabled()) {
+                        return;
+                    }
+                    setUserChecked(!mChecked);
+                    if (!callChangeListener(mChecked)) {
+                        setUserChecked(!mChecked);
+                    } else {
+                        persistBoolean(mChecked);
+                    }
+                }
+            });
+        }
+
+        mSwitch = (Switch) holder.findViewById(R.id.switchWidget);
+        if (mSwitch != null) {
+            mSwitch.setContentDescription(getTitle());
+            mSwitch.setChecked(mChecked);
+        }
+    }
+
+    public void setUserChecked(boolean checked) {
+        setChecked(checked);
+        mDcDimmingManager.setDcDimming(checked);
+        updateSummary(mDcDimmingManager.isDcDimmingOn());
+    }
+
+    private void updateSummary(boolean active) {
+        String summary;
+        if (mDcDimmingManager.getAutoMode() != MODE_AUTO_OFF) {
+            summary = getContext().getString(active
+                    ? R.string.dark_ui_summary_on_auto_mode_auto
+                    : R.string.dark_ui_summary_off_auto_mode_auto);
+        } else {
+            summary = getContext().getString(active
+                    ? R.string.dark_ui_summary_on_auto_mode_never
+                    : R.string.dark_ui_summary_off_auto_mode_never);
+        }
+        setSummary(summary);
+    }
+
+    public void setChecked(boolean checked) {
+        mChecked = checked;
+        if (mSwitch != null) {
+            mSwitch.setChecked(checked);
+        }
+    }
+
+    private class SettingsObserver extends ContentObserver {
+
+        SettingsObserver(Handler handler) {
+            super(handler);
+        }
+
+        void observe() {
+            ContentResolver resolver = getContext().getContentResolver();
+            resolver.registerContentObserver(Settings.System.getUriFor(
+                    Settings.System.DC_DIMMING_AUTO_MODE), false, this,
+                    UserHandle.USER_ALL);
+            resolver.registerContentObserver(Settings.System.getUriFor(
+                    Settings.System.DC_DIMMING_STATE), false, this,
+                    UserHandle.USER_ALL);
+        }
+
+        @Override
+        public void onChange(boolean selfChange) {
+            updateSummary(mDcDimmingManager.isDcDimmingOn());
+            setChecked(mDcDimmingManager.isDcDimmingOn());
+        }
+    }
+}

--- a/src/com/android/settings/display/DcDimmingSettings.java
+++ b/src/com/android/settings/display/DcDimmingSettings.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2020-22 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import static android.hardware.display.DcDimmingManager.MODE_AUTO_OFF;
+import static android.hardware.display.DcDimmingManager.MODE_AUTO_TIME;
+
+import android.content.Context;
+import android.hardware.display.DcDimmingManager;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.provider.SearchIndexableResource;
+import android.util.Log;
+import android.widget.Switch;
+
+import androidx.preference.DropDownPreference;
+import androidx.preference.Preference;
+
+import com.android.settings.R;
+import com.android.settings.dashboard.DashboardFragment;
+import com.android.settings.search.BaseSearchIndexProvider;
+import com.android.settingslib.core.AbstractPreferenceController;
+import com.android.settingslib.search.Indexable;
+import com.android.settingslib.search.SearchIndexable;
+import com.android.settingslib.widget.MainSwitchPreference;
+import com.android.settingslib.widget.OnMainSwitchChangeListener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Settings screen for DC Dimming.
+ */
+@SearchIndexable(forTarget = SearchIndexable.ALL & ~SearchIndexable.ARC)
+public class DcDimmingSettings extends DashboardFragment
+        implements Preference.OnPreferenceChangeListener, OnMainSwitchChangeListener  {
+
+    private static final String TAG = "DcDimmingSettings";
+
+    private static final String KEY_MAIN_SWITCH = "dc_dimming_activated";
+    private static final String KEY_AUTO_MODE = "dc_dimming_auto_mode";
+
+    private DcDimmingManager mDcDimmingManager;
+    private Context mContext;
+
+    private DropDownPreference mAutoPref;
+    private MainSwitchPreference mPreference;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mContext = getContext();
+        mDcDimmingManager = (DcDimmingManager) getSystemService(Context.DC_DIM_SERVICE);
+
+        if (mDcDimmingManager == null || !mDcDimmingManager.isAvailable()) {
+            return;
+        }
+
+        mPreference = findPreference(KEY_MAIN_SWITCH);
+        mPreference.addOnSwitchChangeListener(this);
+        mPreference.updateStatus(mDcDimmingManager.isDcDimmingOn());
+
+        mAutoPref = findPreference(KEY_AUTO_MODE);
+        mAutoPref.setEntries(new CharSequence[]{
+                mContext.getString(R.string.dark_ui_auto_mode_never),
+                mContext.getString(R.string.dark_ui_auto_mode_auto)
+        });
+        mAutoPref.setEntryValues(new CharSequence[]{
+                String.valueOf(MODE_AUTO_OFF),
+                String.valueOf(MODE_AUTO_TIME)
+        });
+        mAutoPref.setValue(String.valueOf(mDcDimmingManager.getAutoMode()));
+        mAutoPref.setOnPreferenceChangeListener(this);
+    }
+
+    @Override
+    protected int getPreferenceScreenResId() {
+        return R.xml.dc_dimming_settings;
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return -1;
+    }
+
+    @Override
+    protected String getLogTag() {
+        return TAG;
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        if (preference == mAutoPref) {
+            mDcDimmingManager.setAutoMode(Integer.parseInt((String) newValue));
+        }
+        return true;
+    }
+
+    @Override
+    public void onSwitchChanged(Switch switchView, boolean isChecked) {
+        mDcDimmingManager.setDcDimming(isChecked);
+    }
+
+    public static final Indexable.SearchIndexProvider SEARCH_INDEX_DATA_PROVIDER =
+            new BaseSearchIndexProvider() {
+                @Override
+                public List<SearchIndexableResource> getXmlResourcesToIndex(Context context,
+                        boolean enabled) {
+                    final ArrayList<SearchIndexableResource> result = new ArrayList<>();
+                    final SearchIndexableResource sir = new SearchIndexableResource(context);
+                    sir.xmlResId = R.xml.dc_dimming_settings;
+                    result.add(sir);
+                    return result;
+                }
+
+                @Override
+                protected boolean isPageSearchEnabled(Context context) {
+                    DcDimmingManager dm = (DcDimmingManager) context
+                            .getSystemService(Context.DC_DIM_SERVICE);
+                    return dm != null && dm.isAvailable();
+                }
+
+                @Override
+                public List<AbstractPreferenceController> createPreferenceControllers(
+                        Context context) {
+                    return new ArrayList(1);
+                }
+            };
+}

--- a/src/com/android/settings/display/DcDimmingSettings.java
+++ b/src/com/android/settings/display/DcDimmingSettings.java
@@ -23,7 +23,8 @@ import android.os.Bundle;
 import android.provider.Settings;
 import android.provider.SearchIndexableResource;
 import android.util.Log;
-import android.widget.Switch;
+import android.widget.CompoundButton;
+import android.widget.CompoundButton.OnCheckedChangeListener;
 
 import androidx.preference.DropDownPreference;
 import androidx.preference.Preference;
@@ -35,7 +36,6 @@ import com.android.settingslib.core.AbstractPreferenceController;
 import com.android.settingslib.search.Indexable;
 import com.android.settingslib.search.SearchIndexable;
 import com.android.settingslib.widget.MainSwitchPreference;
-import com.android.settingslib.widget.OnMainSwitchChangeListener;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +45,7 @@ import java.util.List;
  */
 @SearchIndexable(forTarget = SearchIndexable.ALL & ~SearchIndexable.ARC)
 public class DcDimmingSettings extends DashboardFragment
-        implements Preference.OnPreferenceChangeListener, OnMainSwitchChangeListener  {
+        implements Preference.OnPreferenceChangeListener, OnCheckedChangeListener {
 
     private static final String TAG = "DcDimmingSettings";
 
@@ -110,7 +110,7 @@ public class DcDimmingSettings extends DashboardFragment
     }
 
     @Override
-    public void onSwitchChanged(Switch switchView, boolean isChecked) {
+    public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
         mDcDimmingManager.setDcDimming(isChecked);
     }
 

--- a/src/com/android/settings/display/DisplayCutoutForceFullscreenSettings.kt
+++ b/src/com/android/settings/display/DisplayCutoutForceFullscreenSettings.kt
@@ -47,6 +47,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.android.internal.util.evolution.cutout.CutoutFullscreenController
 
 import com.android.settings.R
+import com.android.settings.SettingsActivity
 
 import com.google.android.material.appbar.AppBarLayout
 
@@ -61,7 +62,7 @@ class DisplayCutoutForceFullscreenSettings: Fragment(R.layout.cutout_force_fulls
     private lateinit var userManager: UserManager
     private lateinit var userInfos: List<UserInfo>
 
-    private var appBarLayout: AppBarLayout? = requireActivity().findViewById(R.id.app_bar)
+    private var appBarLayout: AppBarLayout? = null
     private var searchText = ""
     private var customFilter: ((PackageInfo) -> Boolean)? = null
     private var comparator: ((PackageInfo, PackageInfo) -> Int)? = null
@@ -82,6 +83,7 @@ class DisplayCutoutForceFullscreenSettings: Fragment(R.layout.cutout_force_fulls
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
         requireActivity().setTitle(getTitle())
+        appBarLayout = requireActivity().findViewById(R.id.app_bar)
         activityManager = requireContext().getSystemService(ActivityManager::class.java) as ActivityManager
         packageManager = requireContext().packageManager
         packageList = packageManager.getInstalledPackages(PackageManager.MATCH_ANY_USER)

--- a/src/com/android/settings/display/DisplayRotationPreferenceController.java
+++ b/src/com/android/settings/display/DisplayRotationPreferenceController.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.settings.display;
+
+import android.content.Context;
+
+import androidx.preference.Preference;
+
+import com.android.settings.core.BasePreferenceController;
+import com.android.settings.core.PreferenceControllerMixin;
+
+import com.android.internal.view.RotationPolicy;
+
+import com.android.settings.R;
+
+public class DisplayRotationPreferenceController extends BasePreferenceController implements
+        PreferenceControllerMixin {
+
+    public DisplayRotationPreferenceController(Context context, String preferenceKey) {
+        super(context, preferenceKey);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return AVAILABLE;
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        String summary = RotationPolicy.isRotationLocked(mContext) ?
+                            mContext.getString(R.string.display_rotation_disabled) :
+                            mContext.getString(R.string.display_rotation_enabled);
+        preference.setSummary(summary);
+    }
+}

--- a/src/com/android/settings/display/LowPowerRefreshRatePreferenceController.java
+++ b/src/com/android/settings/display/LowPowerRefreshRatePreferenceController.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2021 crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import static android.provider.Settings.System.LOW_POWER_REFRESH_RATE;
+
+import android.content.Context;
+import android.provider.Settings;
+import android.view.Display;
+
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+
+import com.android.settings.R;
+import com.android.settings.core.BasePreferenceController;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class LowPowerRefreshRatePreferenceController extends BasePreferenceController implements
+        Preference.OnPreferenceChangeListener {
+
+    private static final String KEY_LOW_POWER_REFRESH_RATE = "low_power_refresh_rate";
+
+    private ListPreference mListPreference;
+
+    private List<String> mEntries = new ArrayList<>();
+    private List<String> mValues = new ArrayList<>();
+
+    public LowPowerRefreshRatePreferenceController(Context context) {
+        super(context, KEY_LOW_POWER_REFRESH_RATE);
+
+        if (mContext.getResources().getBoolean(R.bool.config_show_refresh_rate_controls)) {
+            Display.Mode mode = mContext.getDisplay().getMode();
+            Display.Mode[] modes = mContext.getDisplay().getSupportedModes();
+            for (Display.Mode m : modes) {
+                if (m.getPhysicalWidth() == mode.getPhysicalWidth() &&
+                        m.getPhysicalHeight() == mode.getPhysicalHeight()) {
+                    mEntries.add(String.format("%.02fHz", m.getRefreshRate())
+                            .replaceAll("[\\.,]00", ""));
+                    mValues.add(String.format(Locale.US, "%.02f", m.getRefreshRate()));
+                }
+            }
+        }
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return mEntries.size() > 1 ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return KEY_LOW_POWER_REFRESH_RATE;
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        mListPreference = screen.findPreference(getPreferenceKey());
+        mListPreference.setEntries(mEntries.toArray(new String[mEntries.size()]));
+        mListPreference.setEntryValues(mValues.toArray(new String[mValues.size()]));
+
+        super.displayPreference(screen);
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        final float currentValue = Settings.System.getFloat(mContext.getContentResolver(),
+                LOW_POWER_REFRESH_RATE, 60f);
+        int index = mListPreference.findIndexOfValue(
+                String.format(Locale.US, "%.02f", currentValue));
+        if (index < 0) index = 0;
+        mListPreference.setValueIndex(index);
+        mListPreference.setSummary(mListPreference.getEntries()[index]);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        Settings.System.putFloat(mContext.getContentResolver(), LOW_POWER_REFRESH_RATE,
+                Float.valueOf((String) newValue));
+        updateState(preference);
+        return true;
+    }
+
+}

--- a/src/com/android/settings/display/RefreshRatePreferenceController.java
+++ b/src/com/android/settings/display/RefreshRatePreferenceController.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.PowerManager;
+
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+
+import com.android.settings.R;
+import com.android.settings.core.BasePreferenceController;
+import com.android.settingslib.core.lifecycle.LifecycleObserver;
+import com.android.settingslib.core.lifecycle.events.OnStart;
+import com.android.settingslib.core.lifecycle.events.OnStop;
+
+public class RefreshRatePreferenceController extends BasePreferenceController
+        implements LifecycleObserver, OnStart, OnStop {
+
+    private static final String TAG = "RefreshRatePreferenceController";
+
+    private RefreshRateUtils mUtils;
+    private Preference mPreference;
+    private final PowerManager mPowerManager;
+
+    private final BroadcastReceiver mReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (mPreference != null)
+                updateState(mPreference);
+        }
+    };
+
+    public RefreshRatePreferenceController(Context context, String preferenceKey) {
+        super(context, preferenceKey);
+        mUtils = new RefreshRateUtils(context);
+        mPowerManager = context.getSystemService(PowerManager.class);
+    }
+
+    @Override
+    public void onStart() {
+        mContext.registerReceiver(mReceiver,
+                new IntentFilter(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED));
+    }
+
+    @Override
+    public void onStop() {
+        mContext.unregisterReceiver(mReceiver);
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+        mPreference = screen.findPreference(getPreferenceKey());
+    }
+
+    @Override
+    public CharSequence getSummary() {
+        if (mPowerManager.isPowerSaveMode()) {
+            return mContext.getString(R.string.dark_ui_mode_disabled_summary_dark_theme_on);
+        }
+        return mContext.getString(mUtils.isVrrEnabled() ? R.string.refresh_rate_summary_vrr_on
+                : R.string.refresh_rate_summary_vrr_off, mUtils.getCurrentRefreshRate());
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return mUtils.isHighRefreshRateAvailable() ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        super.updateState(preference);
+        preference.setEnabled(!mPowerManager.isPowerSaveMode());
+    }
+}

--- a/src/com/android/settings/display/RefreshRateSettings.java
+++ b/src/com/android/settings/display/RefreshRateSettings.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2023 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.util.Log;
+
+import androidx.preference.PreferenceScreen;
+import androidx.preference.SwitchPreference;
+
+import com.android.settings.R;
+import com.android.settings.search.BaseSearchIndexProvider;
+import com.android.settings.widget.RadioButtonPickerFragment;
+import com.android.settingslib.search.SearchIndexable;
+import com.android.settingslib.widget.CandidateInfo;
+import com.android.settingslib.widget.FooterPreference;
+import com.android.settingslib.widget.MainSwitchPreference;
+import com.android.settingslib.widget.SelectorWithWidgetPreference;
+import com.android.settingslib.widget.TopIntroPreference;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Preference fragment used for switching refresh rate */
+@SearchIndexable
+public class RefreshRateSettings extends RadioButtonPickerFragment {
+
+    private static final String TAG = "RefreshRateSettings";
+    private static final String KEY_VRR_PREF = "refresh_rate_vrr";
+
+    private Context mContext;
+    private RefreshRateUtils mUtils;
+    private SwitchPreference mVrrSwitchPref;
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        mContext = context;
+        mUtils = new RefreshRateUtils(context);
+    }
+
+    @Override
+    protected int getPreferenceScreenResId() {
+        return R.xml.refresh_rate_settings;
+    }
+
+    @Override
+    protected void addStaticPreferences(PreferenceScreen screen) {
+        mVrrSwitchPref = new SwitchPreference(screen.getContext());
+        mVrrSwitchPref.setKey(KEY_VRR_PREF);
+        mVrrSwitchPref.setTitle(R.string.refresh_rate_vrr_title);
+        mVrrSwitchPref.setSummary(R.string.refresh_rate_vrr_summary);
+        mVrrSwitchPref.setOnPreferenceChangeListener((pref, newValue) -> {
+            mUtils.setVrrEnabled((Boolean) newValue);
+            return true;
+        });
+        screen.addPreference(mVrrSwitchPref);
+        updateVrrPref();
+
+        final FooterPreference footerPreference = new FooterPreference(screen.getContext());
+        footerPreference.setTitle(R.string.refresh_rate_footer);
+        footerPreference.setSelectable(false);
+        footerPreference.setLayoutResource(com.android.settingslib.widget.preference.footer.R.layout.preference_footer);
+        screen.addPreference(footerPreference);
+    }
+
+    @Override
+    protected List<? extends CandidateInfo> getCandidates() {
+        return mUtils.getRefreshRates().stream()
+                .filter(r -> r >= RefreshRateUtils.DEFAULT_REFRESH_RATE)
+                .map(RefreshRateCandidateInfo::new)
+                .collect(Collectors.toList());
+    }
+
+    private void updateVrrPref() {
+        if (mVrrSwitchPref == null) return;
+        mVrrSwitchPref.setEnabled(mUtils.isVrrPossible());
+        mVrrSwitchPref.setChecked(mUtils.isVrrEnabled());
+    }
+
+    @Override
+    protected String getDefaultKey() {
+        return String.valueOf(mUtils.getCurrentRefreshRate());
+    }
+
+    @Override
+    protected boolean setDefaultKey(final String key) {
+        final int refreshRate = Integer.parseInt(key);
+        mUtils.setCurrentRefreshRate(refreshRate);
+        updateVrrPref();
+        return true;
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return -1;
+    }
+
+    private class RefreshRateCandidateInfo extends CandidateInfo {
+        private final CharSequence mLabel;
+        private final String mKey;
+
+        RefreshRateCandidateInfo(Integer refreshRate) {
+            super(true);
+            mLabel = String.format("%d Hz", refreshRate.intValue());
+            mKey = refreshRate.toString();
+        }
+
+        @Override
+        public CharSequence loadLabel() {
+            return mLabel;
+        }
+
+        @Override
+        public Drawable loadIcon() {
+            return null;
+        }
+
+        @Override
+        public String getKey() {
+            return mKey;
+        }
+    }
+
+    public static final BaseSearchIndexProvider SEARCH_INDEX_DATA_PROVIDER =
+            new BaseSearchIndexProvider(R.xml.refresh_rate_settings) {
+                @Override
+                protected boolean isPageSearchEnabled(Context context) {
+                    return new RefreshRateUtils(context).isHighRefreshRateAvailable();
+                }
+            };
+}

--- a/src/com/android/settings/display/RefreshRateSettings.java
+++ b/src/com/android/settings/display/RefreshRateSettings.java
@@ -21,7 +21,8 @@ import android.graphics.drawable.Drawable;
 import android.util.Log;
 
 import androidx.preference.PreferenceScreen;
-import androidx.preference.SwitchPreference;
+import androidx.preference.SwitchPreferenceCompat;
+import androidx.preference.TwoStatePreference;
 
 import com.android.settings.R;
 import com.android.settings.search.BaseSearchIndexProvider;
@@ -45,7 +46,7 @@ public class RefreshRateSettings extends RadioButtonPickerFragment {
 
     private Context mContext;
     private RefreshRateUtils mUtils;
-    private SwitchPreference mVrrSwitchPref;
+    private TwoStatePreference mVrrSwitchPref;
 
     @Override
     public void onAttach(Context context) {
@@ -61,7 +62,7 @@ public class RefreshRateSettings extends RadioButtonPickerFragment {
 
     @Override
     protected void addStaticPreferences(PreferenceScreen screen) {
-        mVrrSwitchPref = new SwitchPreference(screen.getContext());
+        mVrrSwitchPref = new SwitchPreferenceCompat(screen.getContext());
         mVrrSwitchPref.setKey(KEY_VRR_PREF);
         mVrrSwitchPref.setTitle(R.string.refresh_rate_vrr_title);
         mVrrSwitchPref.setSummary(R.string.refresh_rate_vrr_summary);

--- a/src/com/android/settings/display/RefreshRateUtils.java
+++ b/src/com/android/settings/display/RefreshRateUtils.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2024 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import android.content.Context;
+import android.provider.Settings;
+import android.util.Log;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RefreshRateUtils {
+
+    private static final String TAG = "RefreshRateUtils";
+
+    static final int DEFAULT_REFRESH_RATE = 60;
+    static final int DEFAULT_MIN_REFRESH_RATE = 0; // matches fwb. should be 60 though?
+
+    private Context mContext;
+    private List<Integer> mRefreshRates;
+    private int mMinRefreshRate, mMaxRefreshRate;
+
+    RefreshRateUtils(Context context) {
+        mContext = context;
+        mRefreshRates = getRefreshRates();
+        mMinRefreshRate = Collections.min(mRefreshRates);
+        mMaxRefreshRate = Collections.max(mRefreshRates);
+    }
+
+    List<Integer> getRefreshRates() {
+        return Arrays.stream(mContext.getDisplay().getSupportedModes())
+                .map(m -> Math.round(m.getRefreshRate()))
+                .sorted().distinct().collect(Collectors.toList());
+    }
+
+    boolean isHighRefreshRateAvailable() {
+        return mRefreshRates.stream()
+                .filter(r -> r > DEFAULT_REFRESH_RATE)
+                .count() > 0;
+    }
+
+    private int roundToNearestRefreshRate(int refreshRate, boolean floor) {
+        if (mRefreshRates.contains(refreshRate)) return refreshRate;
+        int findRefreshRate = mMinRefreshRate;
+        for (Integer knownRefreshRate : mRefreshRates) {
+            if (!floor) findRefreshRate = knownRefreshRate;
+            if (knownRefreshRate > refreshRate) break;
+            if (floor) findRefreshRate = knownRefreshRate;
+        }
+        return findRefreshRate;
+    }
+
+    private float getDefaultPeakRefreshRate() {
+        return (float) mContext.getResources().getInteger(
+                com.android.internal.R.integer.config_defaultPeakRefreshRate);
+    }
+
+    private int getPeakRefreshRate() {
+        final int peakRefreshRate = Math.round(Settings.System.getFloat(
+                mContext.getContentResolver(),
+                Settings.System.PEAK_REFRESH_RATE, getDefaultPeakRefreshRate()));
+        return peakRefreshRate < mMinRefreshRate ? mMaxRefreshRate
+                : roundToNearestRefreshRate(peakRefreshRate, true);
+    }
+
+    private void setPeakRefreshRate(int refreshRate) {
+        Settings.System.putFloat(mContext.getContentResolver(),
+                Settings.System.PEAK_REFRESH_RATE, (float) refreshRate);
+    }
+
+    private int getMinRefreshRate() {
+        final int minRefreshRate = Math.round(Settings.System.getFloat(
+                mContext.getContentResolver(), Settings.System.MIN_REFRESH_RATE,
+                (float) DEFAULT_MIN_REFRESH_RATE));
+        return minRefreshRate == DEFAULT_MIN_REFRESH_RATE ? DEFAULT_MIN_REFRESH_RATE
+                : roundToNearestRefreshRate(minRefreshRate, false);
+    }
+
+    private void setMinRefreshRate(int refreshRate) {
+        Settings.System.putFloat(mContext.getContentResolver(),
+                Settings.System.MIN_REFRESH_RATE, (float) refreshRate);
+    }
+
+    int getCurrentRefreshRate() {
+        return Math.max(getMinRefreshRate(), getPeakRefreshRate());
+    }
+
+    void setCurrentRefreshRate(int refreshRate) {
+        setPeakRefreshRate(refreshRate);
+        setMinRefreshRate(isVrrEnabled() ? DEFAULT_MIN_REFRESH_RATE : refreshRate);
+    }
+
+    boolean isVrrPossible() {
+        return getCurrentRefreshRate() > DEFAULT_REFRESH_RATE;
+    }
+
+    boolean isVrrEnabled() {
+        return getMinRefreshRate() <= DEFAULT_MIN_REFRESH_RATE;
+    }
+
+    void setVrrEnabled(boolean enable) {
+        setMinRefreshRate(enable ? DEFAULT_MIN_REFRESH_RATE : getCurrentRefreshRate());
+    }
+}

--- a/src/com/android/settings/display/ScreenResolutionController.java
+++ b/src/com/android/settings/display/ScreenResolutionController.java
@@ -88,7 +88,9 @@ public class ScreenResolutionController extends BasePreferenceController {
 
     @Override
     public int getAvailabilityStatus() {
-        return (checkSupportedResolutions()) ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+        return !(mContext.getResources().getBoolean(
+                R.bool.config_show_custom_screen_resolution_switch)) &&
+                (checkSupportedResolutions()) ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
     }
 
     @Override

--- a/src/com/android/settings/display/ScreenResolutionFragment.java
+++ b/src/com/android/settings/display/ScreenResolutionFragment.java
@@ -44,6 +44,8 @@ import com.android.settingslib.widget.FooterPreference;
 import com.android.settingslib.widget.IllustrationPreference;
 import com.android.settingslib.widget.SelectorWithWidgetPreference;
 
+import com.android.internal.util.evolution.EvolutionUtils;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -176,6 +178,7 @@ public class ScreenResolutionFragment extends RadioButtonPickerFragment {
             /** Apply the resolution change. */
             Log.i(TAG, "setUserPreferredDisplayMode: " + mode);
             mDefaultDisplay.setUserPreferredDisplayMode(mode);
+            EvolutionUtils.restartSystemUi(getContext());
         } catch (Exception e) {
             Log.e(TAG, "setUserPreferredDisplayMode() failed", e);
             return;

--- a/src/com/android/settings/display/SmartAutoRotatePreferenceFragment.java
+++ b/src/com/android/settings/display/SmartAutoRotatePreferenceFragment.java
@@ -20,6 +20,7 @@ import static com.android.settings.display.SmartAutoRotateController.isRotationR
 import android.app.settings.SettingsEnums;
 import android.content.Context;
 import android.os.Bundle;
+import android.os.UserHandle;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -27,6 +28,8 @@ import android.view.ViewGroup;
 
 import androidx.annotation.VisibleForTesting;
 import androidx.preference.Preference;
+import androidx.preference.SwitchPreference;
+import android.provider.Settings;
 
 import com.android.settings.R;
 import com.android.settings.SettingsActivity;
@@ -55,6 +58,22 @@ public class SmartAutoRotatePreferenceFragment extends DashboardFragment {
     @VisibleForTesting
     static final String AUTO_ROTATE_SWITCH_PREFERENCE_KEY = "auto_rotate_switch";
     private static final String KEY_FOOTER_PREFERENCE = "auto_rotate_footer_preference";
+
+
+    private static final String ROTATION_0_PREF = "display_rotation_0";
+    private static final String ROTATION_90_PREF = "display_rotation_90";
+    private static final String ROTATION_180_PREF = "display_rotation_180";
+    private static final String ROTATION_270_PREF = "display_rotation_270";
+
+    private SwitchPreference mRotation0Pref;
+    private SwitchPreference mRotation90Pref;
+    private SwitchPreference mRotation180Pref;
+    private SwitchPreference mRotation270Pref;
+
+    public static final int ROTATION_0_MODE = 1;
+    public static final int ROTATION_90_MODE = 2;
+    public static final int ROTATION_180_MODE = 4;
+    public static final int ROTATION_270_MODE = 8;
 
     @Override
     protected int getPreferenceScreenResId() {
@@ -86,6 +105,20 @@ public class SmartAutoRotatePreferenceFragment extends DashboardFragment {
             footerPreference.setVisible(isRotationResolverServiceAvailable(activity));
             setupFooter();
         }
+
+        mRotation0Pref = findPreference(ROTATION_0_PREF);
+        mRotation90Pref = findPreference(ROTATION_90_PREF);
+        mRotation180Pref = findPreference(ROTATION_180_PREF);
+        mRotation270Pref = findPreference(ROTATION_270_PREF);
+
+        int mode = Settings.System.getIntForUser(getContentResolver(),
+                        Settings.System.ACCELEROMETER_ROTATION_ANGLES,
+                        ROTATION_0_MODE|ROTATION_90_MODE|ROTATION_270_MODE, UserHandle.USER_CURRENT);
+
+        mRotation0Pref.setChecked((mode & ROTATION_0_MODE) != 0);
+        mRotation90Pref.setChecked((mode & ROTATION_90_MODE) != 0);
+        mRotation180Pref.setChecked((mode & ROTATION_180_MODE) != 0);
+        mRotation270Pref.setChecked((mode & ROTATION_270_MODE) != 0);
         return view;
     }
 
@@ -136,6 +169,32 @@ public class SmartAutoRotatePreferenceFragment extends DashboardFragment {
             });
             pref.setLearnMoreText(getString(R.string.auto_rotate_link_a11y));
         }
+    }
+
+    @Override
+    public boolean onPreferenceTreeClick(Preference preference) {
+        if (preference == mRotation0Pref ||
+                preference == mRotation90Pref ||
+                preference == mRotation180Pref ||
+                preference == mRotation270Pref) {
+            int mode = 0;
+            if (mRotation0Pref.isChecked())
+                mode |= ROTATION_0_MODE;
+            if (mRotation90Pref.isChecked())
+                mode |= ROTATION_90_MODE;
+            if (mRotation180Pref.isChecked())
+                mode |= ROTATION_180_MODE;
+            if (mRotation270Pref.isChecked())
+                mode |= ROTATION_270_MODE;
+            if (mode == 0) {
+                mode |= ROTATION_0_MODE;
+                mRotation0Pref.setChecked(true);
+            }
+            Settings.System.putIntForUser(getActivity().getApplicationContext().getContentResolver(),
+                    Settings.System.ACCELEROMETER_ROTATION_ANGLES, mode, UserHandle.USER_CURRENT);
+            return true;
+        }
+        return super.onPreferenceTreeClick(preference);
     }
 
     public static final Indexable.SearchIndexProvider SEARCH_INDEX_DATA_PROVIDER =

--- a/src/com/android/settings/display/SmartAutoRotatePreferenceFragment.java
+++ b/src/com/android/settings/display/SmartAutoRotatePreferenceFragment.java
@@ -59,12 +59,13 @@ public class SmartAutoRotatePreferenceFragment extends DashboardFragment {
     static final String AUTO_ROTATE_SWITCH_PREFERENCE_KEY = "auto_rotate_switch";
     private static final String KEY_FOOTER_PREFERENCE = "auto_rotate_footer_preference";
 
-
+    private static final String LOCKSCREEN_ROTATION = "lockscreen_rotation";
     private static final String ROTATION_0_PREF = "display_rotation_0";
     private static final String ROTATION_90_PREF = "display_rotation_90";
     private static final String ROTATION_180_PREF = "display_rotation_180";
     private static final String ROTATION_270_PREF = "display_rotation_270";
 
+    private SwitchPreference mLockScreenRotationPref;
     private SwitchPreference mRotation0Pref;
     private SwitchPreference mRotation90Pref;
     private SwitchPreference mRotation180Pref;
@@ -106,6 +107,7 @@ public class SmartAutoRotatePreferenceFragment extends DashboardFragment {
             setupFooter();
         }
 
+        mLockScreenRotationPref = findPreference(LOCKSCREEN_ROTATION);
         mRotation0Pref = findPreference(ROTATION_0_PREF);
         mRotation90Pref = findPreference(ROTATION_90_PREF);
         mRotation180Pref = findPreference(ROTATION_180_PREF);
@@ -115,6 +117,12 @@ public class SmartAutoRotatePreferenceFragment extends DashboardFragment {
                         Settings.System.ACCELEROMETER_ROTATION_ANGLES,
                         ROTATION_0_MODE|ROTATION_90_MODE|ROTATION_270_MODE, UserHandle.USER_CURRENT);
 
+        boolean configEnableLockRotation = getResources().
+                        getBoolean(com.android.internal.R.bool.config_enableLockScreenRotation);
+        boolean lockScreenRotationEnabled = Settings.System.getInt(getContentResolver(),
+                        Settings.System.LOCKSCREEN_ROTATION, configEnableLockRotation ? 1 : 0) != 0;
+
+        mLockScreenRotationPref.setChecked(lockScreenRotationEnabled);
         mRotation0Pref.setChecked((mode & ROTATION_0_MODE) != 0);
         mRotation90Pref.setChecked((mode & ROTATION_90_MODE) != 0);
         mRotation180Pref.setChecked((mode & ROTATION_180_MODE) != 0);
@@ -192,6 +200,11 @@ public class SmartAutoRotatePreferenceFragment extends DashboardFragment {
             }
             Settings.System.putIntForUser(getActivity().getApplicationContext().getContentResolver(),
                     Settings.System.ACCELEROMETER_ROTATION_ANGLES, mode, UserHandle.USER_CURRENT);
+            return true;
+        } else if (preference == mLockScreenRotationPref) {
+            Settings.System.putInt(getContentResolver(),
+                    Settings.System.LOCKSCREEN_ROTATION,
+                    mLockScreenRotationPref.isChecked() ? 1 : 0);
             return true;
         }
         return super.onPreferenceTreeClick(preference);

--- a/src/com/android/settings/display/SmartPixels.java
+++ b/src/com/android/settings/display/SmartPixels.java
@@ -29,7 +29,8 @@ import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceScreen;
 import androidx.preference.Preference.OnPreferenceChangeListener;
-import androidx.preference.SwitchPreference;
+import androidx.preference.SwitchPreferenceCompat;
+import androidx.preference.TwoStatePreference;
 
 import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
 import com.android.settings.R;

--- a/src/com/android/settings/display/SmartPixels.java
+++ b/src/com/android/settings/display/SmartPixels.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2018-2022 crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import android.content.Context;
+import android.content.ContentResolver;
+import android.content.res.Resources;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.UserHandle;
+import android.provider.Settings;
+
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.Preference.OnPreferenceChangeListener;
+import androidx.preference.SwitchPreference;
+
+import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
+import com.android.settings.R;
+import com.android.settings.dashboard.DashboardFragment;
+
+public class SmartPixels extends DashboardFragment {
+
+    private static final String TAG = "SmartPixels";
+    private static final String SMART_PIXELS_FOOTER = "smart_pixels_footer";
+
+    @Override
+    protected int getPreferenceScreenResId() {
+        return R.xml.evolution_settings_smart_pixels;
+    }
+
+    @Override
+    public void onCreate(Bundle icicle) {
+        super.onCreate(icicle);
+
+        findPreference(SMART_PIXELS_FOOTER).setTitle(R.string.smart_pixels_warning_text);
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsEvent.EVOLVER;
+    }
+
+    @Override
+    protected String getLogTag() {
+        return TAG;
+    }
+}

--- a/src/com/android/settings/display/TouchPollingPreferenceController.java
+++ b/src/com/android/settings/display/TouchPollingPreferenceController.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 The Proton AOSP Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import android.content.Context;
+import android.os.SystemProperties;
+import android.provider.Settings;
+
+import com.android.settings.core.TogglePreferenceController;
+import com.android.settings.R;
+
+public class TouchPollingPreferenceController extends TogglePreferenceController {
+
+    // Settings can only set the debug.* property, so we need to persist it
+    // in system settings. Match the stock setting name for backup compatibility.
+    private static final String SETTINGS_KEY = "touch_polling_enabled";
+    private static final String PROP_NAME = "debug.touch_polling_mode";
+
+    public TouchPollingPreferenceController(Context context, String preferenceKey) {
+        super(context, preferenceKey);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return mContext.getResources().getBoolean(R.bool.config_supportTouchPollingMode)
+            ? AVAILABLE
+            : UNSUPPORTED_ON_DEVICE;
+    }
+
+    @Override
+    public boolean setChecked(boolean value) {
+        Settings.Secure.putInt(mContext.getContentResolver(), SETTINGS_KEY, value ? 1 : 0);
+        SystemProperties.set(PROP_NAME, value ? "1" : "0");
+        return true;
+    }
+
+    @Override
+    public boolean isChecked() {
+        // debug prop isn't persistent
+        return Settings.Secure.getInt(mContext.getContentResolver(), SETTINGS_KEY, 0) == 1;
+    }
+
+    @Override
+    public int getSliceHighlightMenuRes() {
+        return R.string.menu_key_display;
+    }
+}

--- a/src/com/android/settings/evolution/notificationlight/ApplicationLightPreference.java
+++ b/src/com/android/settings/evolution/notificationlight/ApplicationLightPreference.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (C) 2012 The CyanogenMod Project
+ *               2017-2022 The LineageOS Project
+*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.evolution.notificationlight;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.graphics.drawable.ShapeDrawable;
+import android.graphics.drawable.shapes.OvalShape;
+import android.os.Bundle;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.preference.PreferenceViewHolder;
+
+import com.android.internal.evolution.notification.LightsCapabilities;
+
+import com.evolution.settings.preference.CustomDialogPreference;
+import com.android.settings.R;
+
+public class ApplicationLightPreference extends CustomDialogPreference<LightSettingsDialog>
+        implements View.OnLongClickListener {
+
+    private static final String TAG = "AppLightPreference";
+    public static final int DEFAULT_TIME = 1000;
+    public static final int DEFAULT_COLOR = 0xffffff;
+
+    private ImageView mLightColorView;
+    private TextView mOnValueView;
+    private TextView mOffValueView;
+
+    private int mColorValue;
+    private int mOnValue;
+    private int mOffValue;
+    private boolean mOnOffChangeable;
+
+    private boolean mHasDefaults;
+    private int mDefaultColorValue;
+    private int mDefaultOnValue;
+    private int mDefaultOffValue;
+
+    private int mLedBrightness;
+
+    private LightSettingsDialog mDialog;
+
+    public interface ItemLongClickListener {
+        boolean onItemLongClick(String key);
+    }
+
+    private ItemLongClickListener mLongClickListener;
+
+    public ApplicationLightPreference(Context context, AttributeSet attrs) {
+        this(context, attrs, DEFAULT_COLOR, DEFAULT_TIME, DEFAULT_TIME);
+    }
+
+    public ApplicationLightPreference(Context context, AttributeSet attrs,
+                                      int color, int onValue, int offValue) {
+        this(context, attrs, color, onValue, offValue,
+                LightsCapabilities.supports(context, LightsCapabilities.LIGHTS_PULSATING_LED));
+    }
+
+    public ApplicationLightPreference(Context context, AttributeSet attrs,
+                                      int color, int onValue, int offValue,
+                                      boolean onOffChangeable) {
+        super(context, attrs);
+        mColorValue = color;
+        mOnValue = onValue;
+        mOffValue = offValue;
+        mOnOffChangeable = onOffChangeable;
+        mHasDefaults = false;
+        mLedBrightness = 0; // use system brightness
+
+        setWidgetLayoutResource(R.layout.preference_application_light);
+    }
+
+    @Override
+    public boolean onLongClick(View view) {
+        if (mLongClickListener != null) {
+            return mLongClickListener.onItemLongClick(getKey());
+        }
+        return false;
+    }
+
+    public void setOnLongClickListener(ItemLongClickListener l) {
+        mLongClickListener = l;
+    }
+
+    @Override
+    public void onBindViewHolder(PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+
+        mLightColorView = (ImageView) holder.findViewById(R.id.light_color);
+        mOnValueView = (TextView) holder.findViewById(R.id.textViewTimeOnValue);
+        mOffValueView = (TextView) holder.findViewById(R.id.textViewTimeOffValue);
+
+        // Hide the summary text - it takes up too much space on a low res device
+        // We use it for storing the package name for the longClickListener
+        TextView tView = (TextView) holder.findViewById(android.R.id.summary);
+        tView.setVisibility(View.GONE);
+
+        if (!LightsCapabilities.supports(
+                getContext(), LightsCapabilities.LIGHTS_RGB_NOTIFICATION_LED)) {
+            mLightColorView.setVisibility(View.GONE);
+        }
+
+        updatePreferenceViews();
+        holder.itemView.setOnLongClickListener(this);
+    }
+
+    public void onStop() {
+        if (getDialog() != null) {
+            getDialog().onStop();
+        }
+    }
+
+    public void onStart() {
+        if (getDialog() != null) {
+            getDialog().onStart();
+        }
+    }
+
+    private void updatePreferenceViews() {
+        final int size = (int) getContext().getResources().getDimension(
+                R.dimen.oval_notification_size);
+
+        if (mLightColorView != null) {
+            mLightColorView.setEnabled(true);
+            // adjust if necessary to prevent material whiteout
+            final int imageColor = ((mColorValue & 0xF0F0F0) == 0xF0F0F0) ?
+                    (mColorValue - 0x101010) : mColorValue;
+            mLightColorView.setImageDrawable(createOvalShape(size,
+                    0xFF000000 + imageColor));
+        }
+        if (mOnValueView != null) {
+            mOnValueView.setText(mapLengthValue(mOnValue));
+        }
+        if (mOffValueView != null) {
+            if (mOnValue == 1 || !mOnOffChangeable) {
+                mOffValueView.setVisibility(View.GONE);
+            } else {
+                mOffValueView.setVisibility(View.VISIBLE);
+            }
+            mOffValueView.setText(mapSpeedValue(mOffValue));
+        }
+    }
+
+    @Override
+    protected boolean onDismissDialog(LightSettingsDialog dialog, int which) {
+        if (which == DialogInterface.BUTTON_NEUTRAL) {
+            // Reset to previously supplied defaults
+            mDialog.setColor(mDefaultColorValue);
+            if (mOnOffChangeable) {
+                mDialog.setPulseSpeedOn(mDefaultOnValue);
+                mDialog.setPulseSpeedOff(mDefaultOffValue);
+            }
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    protected void onDialogClosed(boolean positiveResult) {
+        if (positiveResult) {
+            mColorValue = mDialog.getColor() & 0x00FFFFFF; // strip alpha, led does not support it
+            mOnValue = mDialog.getPulseSpeedOn();
+            mOffValue = mDialog.getPulseSpeedOff();
+            updatePreferenceViews();
+            callChangeListener(null);
+        }
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        mDialog = new LightSettingsDialog(getContext(), 0xFF000000 | mColorValue,
+                mOnValue, mOffValue, mOnOffChangeable, mLedBrightness);
+        mDialog.setAlphaSliderVisible(false);
+
+        // Initialize the buttons with null handlers, as they will get remapped by
+        // CustomPreferenceDialogFragment
+        mDialog.setButton(AlertDialog.BUTTON_POSITIVE,
+                getContext().getResources().getString(R.string.dlg_ok),
+                (DialogInterface.OnClickListener) null);
+        mDialog.setButton(AlertDialog.BUTTON_NEGATIVE,
+                getContext().getResources().getString(R.string.cancel),
+                (DialogInterface.OnClickListener) null);
+        if (mHasDefaults) {
+            mDialog.setButton(AlertDialog.BUTTON_NEUTRAL,
+                    getContext().getResources().getString(R.string.reset),
+                    (DialogInterface.OnClickListener) null);
+        }
+
+        return mDialog;
+    }
+
+
+    /**
+     * Getters and Setters
+     */
+    public int getColor() {
+        return mColorValue;
+    }
+
+    public void setColor(int color) {
+        mColorValue = color;
+        updatePreferenceViews();
+    }
+
+    public int getOnValue() {
+        return mOnValue;
+    }
+
+    public int getOffValue() {
+        return mOffValue;
+    }
+
+    public void setAllValues(int color, int onValue, int offValue) {
+        mColorValue = color;
+        mOnValue = onValue;
+        mOffValue = offValue;
+        updatePreferenceViews();
+    }
+
+    public void setAllValues(int color, int onValue, int offValue, boolean onOffChangeable) {
+        mColorValue = color;
+        mOnValue = onValue;
+        mOffValue = offValue;
+        mOnOffChangeable = onOffChangeable;
+        updatePreferenceViews();
+    }
+
+    public void setDefaultValues(int color, int onValue, int offValue) {
+        mDefaultColorValue = color;
+        mDefaultOnValue = onValue;
+        mDefaultOffValue = offValue;
+        mHasDefaults = true;
+    }
+
+    public void setBrightness(int brightness) {
+        mLedBrightness = brightness;
+    }
+
+    /**
+     * Utility methods
+     */
+    private static ShapeDrawable createOvalShape(int size, int color) {
+        ShapeDrawable shape = new ShapeDrawable(new OvalShape());
+        shape.setIntrinsicHeight(size);
+        shape.setIntrinsicWidth(size);
+        shape.getPaint().setColor(color);
+        return shape;
+    }
+
+    private String mapLengthValue(Integer time) {
+        if (!mOnOffChangeable) {
+            return getContext().getResources().getString(R.string.pulse_length_always_on);
+        }
+        if (time == DEFAULT_TIME) {
+            return getContext().getResources().getString(R.string.default_time);
+        }
+
+        String[] timeNames = getContext().getResources().getStringArray(
+                R.array.notification_pulse_length_entries);
+        String[] timeValues = getContext().getResources().getStringArray(
+                R.array.notification_pulse_length_values);
+
+        for (int i = 0; i < timeValues.length; i++) {
+            if (Integer.decode(timeValues[i]).equals(time)) {
+                return timeNames[i];
+            }
+        }
+
+        return getContext().getResources().getString(R.string.custom_time);
+    }
+
+    private String mapSpeedValue(Integer time) {
+        if (time == DEFAULT_TIME) {
+            return getContext().getResources().getString(R.string.default_time);
+        }
+
+        String[] timeNames = getContext().getResources().getStringArray(
+                R.array.notification_pulse_speed_entries);
+        String[] timeValues = getContext().getResources().getStringArray(
+                R.array.notification_pulse_speed_values);
+
+        for (int i = 0; i < timeValues.length; i++) {
+            if (Integer.decode(timeValues[i]).equals(time)) {
+                return timeNames[i];
+            }
+        }
+
+        return getContext().getResources().getString(R.string.custom_time);
+    }
+}

--- a/src/com/android/settings/evolution/notificationlight/BatteryBrightnessPreference.java
+++ b/src/com/android/settings/evolution/notificationlight/BatteryBrightnessPreference.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017-2022 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.evolution.notificationlight;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.os.UserHandle;
+import android.provider.Settings;
+import android.util.AttributeSet;
+
+public class BatteryBrightnessPreference extends BrightnessPreference {
+    private static final String TAG = "BatteryBrightnessPreference";
+
+    private final ContentResolver mResolver;
+
+    public BatteryBrightnessPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        mResolver = context.getContentResolver();
+    }
+
+    @Override
+    protected int getBrightnessSetting() {
+        return Settings.System.getIntForUser(mResolver,
+                Settings.System.BATTERY_LIGHT_BRIGHTNESS_LEVEL,
+                LIGHT_BRIGHTNESS_MAXIMUM, UserHandle.USER_CURRENT);
+    }
+
+    @Override
+    protected void setBrightnessSetting(int brightness) {
+        Settings.System.putIntForUser(mResolver,
+                Settings.System.BATTERY_LIGHT_BRIGHTNESS_LEVEL,
+                brightness, UserHandle.USER_CURRENT);
+    }
+}

--- a/src/com/android/settings/evolution/notificationlight/BatteryBrightnessZenPreference.java
+++ b/src/com/android/settings/evolution/notificationlight/BatteryBrightnessZenPreference.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2017-2022 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.evolution.notificationlight;
+
+import android.content.Context;
+import android.os.UserHandle;
+import android.provider.Settings;
+import android.util.AttributeSet;
+
+public class BatteryBrightnessZenPreference extends BrightnessPreference {
+    private static final String TAG = "BatteryBrightnessZenPreference";
+
+    private final Context mContext;
+
+    public BatteryBrightnessZenPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        mContext = context;
+    }
+
+    @Override
+    protected int getBrightnessSetting() {
+        return Settings.System.getIntForUser(mContext.getContentResolver(),
+                Settings.System.BATTERY_LIGHT_BRIGHTNESS_LEVEL_ZEN,
+                LIGHT_BRIGHTNESS_MAXIMUM, UserHandle.USER_CURRENT);
+    }
+
+    @Override
+    protected void setBrightnessSetting(int brightness) {
+        Settings.System.putIntForUser(mContext.getContentResolver(),
+                Settings.System.BATTERY_LIGHT_BRIGHTNESS_LEVEL_ZEN,
+                brightness, UserHandle.USER_CURRENT);
+    }
+}

--- a/src/com/android/settings/evolution/notificationlight/BatteryLightPreferenceController.java
+++ b/src/com/android/settings/evolution/notificationlight/BatteryLightPreferenceController.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 The PixelExperience Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.evolution.notificationlight;
+
+import android.content.Context;
+import com.android.settings.core.BasePreferenceController;
+
+public class BatteryLightPreferenceController extends BasePreferenceController {
+
+    public static final String KEY = "battery_lights";
+
+    private Context mContext;
+
+    public BatteryLightPreferenceController(Context context, String key) {
+        super(context, key);
+
+        mContext = context;
+    }
+
+    public BatteryLightPreferenceController(Context context) {
+        this(context, KEY);
+
+        mContext = context;
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        int caps = mContext.getResources().getInteger(com.android.internal.R.integer.config_deviceLightCapabilities);
+        return (((caps & 64) == 64) ? AVAILABLE : UNSUPPORTED_ON_DEVICE);
+    }
+
+}

--- a/src/com/android/settings/evolution/notificationlight/BatteryLightSettings.java
+++ b/src/com/android/settings/evolution/notificationlight/BatteryLightSettings.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (C) 2012 The CyanogenMod Project
+ *               2017-2022 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.evolution.notificationlight;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.os.UserHandle;
+import android.provider.Settings;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+
+import androidx.fragment.app.DialogFragment;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceGroup;
+import androidx.preference.PreferenceScreen;
+
+import com.android.internal.evolution.notification.LightsCapabilities;
+import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
+import com.android.settings.R;
+import com.android.settings.SettingsPreferenceFragment;
+
+import com.evolution.settings.preference.CustomDialogPreference;
+import com.evolution.settings.preference.SystemSettingMainSwitchPreference;
+import com.evolution.settings.preference.SystemSettingSwitchPreference;
+
+import java.util.List;
+import java.util.UUID;
+
+public class BatteryLightSettings extends SettingsPreferenceFragment implements
+        Preference.OnPreferenceChangeListener {
+    private static final String TAG = "BatteryLightSettings";
+
+    private static final String KEY_BATTERY_LIGHTS = "battery_lights";
+    private static final String GENERAL_SECTION = "general_section";
+    private static final String COLORS_SECTION = "colors_list";
+    private static final String BRIGHTNESS_SECTION = "brightness_section";
+
+    private static final String LOW_COLOR_PREF = "low_color";
+    private static final String MEDIUM_COLOR_PREF = "medium_color";
+    private static final String FULL_COLOR_PREF = "full_color";
+    private static final String LIGHT_ENABLED_PREF = "battery_light_enabled";
+    private static final String LIGHT_FULL_CHARGE_DISABLED_PREF =
+            "battery_light_full_charge_disabled";
+    private static final String PULSE_ENABLED_PREF = "battery_light_pulse";
+    private static final String BRIGHTNESS_PREFERENCE = "battery_light_brightness_level";
+    private static final String BRIGHTNESS_ZEN_PREFERENCE = "battery_light_brightness_level_zen";
+
+    private ApplicationLightPreference mLowColorPref;
+    private ApplicationLightPreference mMediumColorPref;
+    private ApplicationLightPreference mFullColorPref;
+    private SystemSettingMainSwitchPreference mLightEnabledPref;
+    private SystemSettingSwitchPreference mLightFullChargeDisabledPref;
+    private SystemSettingSwitchPreference mPulseEnabledPref;
+    private BatteryBrightnessPreference mBatteryBrightnessPref;
+    private BatteryBrightnessZenPreference mBatteryBrightnessZenPref;
+    private int mDefaultLowColor;
+    private int mDefaultMediumColor;
+    private int mDefaultFullColor;
+    private boolean mMultiColorLed;
+
+    private static final int MENU_RESET = Menu.FIRST;
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        final Context context = getContext();
+        final Resources res = getResources();
+
+        // Collect battery led capabilities.
+        mMultiColorLed =
+                LightsCapabilities.supports(context, LightsCapabilities.LIGHTS_RGB_BATTERY_LED);
+        // liblights supports brightness control
+        final boolean halAdjustableBrightness = LightsCapabilities.supports(context,
+                LightsCapabilities.LIGHTS_ADJUSTABLE_BATTERY_LED_BRIGHTNESS);
+        final boolean pulsatingLed = LightsCapabilities.supports(context,
+                LightsCapabilities.LIGHTS_PULSATING_LED);
+        final boolean segmentedBatteryLed = LightsCapabilities.supports(context,
+                LightsCapabilities.LIGHTS_SEGMENTED_BATTERY_LED);
+
+        addPreferencesFromResource(R.xml.battery_light_settings);
+        getActivity().getActionBar().setTitle(R.string.battery_light_title);
+
+        PreferenceScreen prefSet = getPreferenceScreen();
+
+        PreferenceGroup generalPrefs = prefSet.findPreference(GENERAL_SECTION);
+
+        mLightEnabledPref = prefSet.findPreference(LIGHT_ENABLED_PREF);
+        mLightFullChargeDisabledPref = prefSet.findPreference(LIGHT_FULL_CHARGE_DISABLED_PREF);
+        mPulseEnabledPref = prefSet.findPreference(PULSE_ENABLED_PREF);
+        mBatteryBrightnessPref = prefSet.findPreference(BRIGHTNESS_PREFERENCE);
+        mBatteryBrightnessZenPref = prefSet.findPreference(BRIGHTNESS_ZEN_PREFERENCE);
+
+        mDefaultLowColor = res.getInteger(
+                com.android.internal.R.integer.config_notificationsBatteryLowARGB);
+        mDefaultMediumColor = res.getInteger(
+                com.android.internal.R.integer.config_notificationsBatteryMediumARGB);
+        mDefaultFullColor = res.getInteger(
+                com.android.internal.R.integer.config_notificationsBatteryFullARGB);
+
+        int batteryBrightness = mBatteryBrightnessPref.getBrightnessSetting();
+
+        if (!pulsatingLed || segmentedBatteryLed) {
+            generalPrefs.removePreference(mPulseEnabledPref);
+        }
+
+        if (mMultiColorLed) {
+            generalPrefs.removePreference(mLightFullChargeDisabledPref);
+            setHasOptionsMenu(true);
+
+            // Low, Medium and full color preferences
+            mLowColorPref = prefSet.findPreference(LOW_COLOR_PREF);
+            mLowColorPref.setOnPreferenceChangeListener(this);
+            mLowColorPref.setDefaultValues(mDefaultLowColor, 0, 0);
+            mLowColorPref.setBrightness(batteryBrightness);
+
+            mMediumColorPref = prefSet.findPreference(MEDIUM_COLOR_PREF);
+            mMediumColorPref.setOnPreferenceChangeListener(this);
+            mMediumColorPref.setDefaultValues(mDefaultMediumColor, 0, 0);
+            mMediumColorPref.setBrightness(batteryBrightness);
+
+            mFullColorPref = prefSet.findPreference(FULL_COLOR_PREF);
+            mFullColorPref.setOnPreferenceChangeListener(this);
+            mFullColorPref.setDefaultValues(mDefaultFullColor, 0, 0);
+            mFullColorPref.setBrightness(batteryBrightness);
+
+            final BrightnessPreference.OnBrightnessChangedListener brightnessListener =
+                    brightness -> {
+                mLowColorPref.setBrightness(brightness);
+                mMediumColorPref.setBrightness(brightness);
+                mFullColorPref.setBrightness(brightness);
+            };
+            mBatteryBrightnessPref.setOnBrightnessChangedListener(brightnessListener);
+        } else {
+            prefSet.removePreference(prefSet.findPreference(COLORS_SECTION));
+            resetColors();
+        }
+
+        // Remove battery LED brightness controls if we can't support them.
+        if (!mMultiColorLed && !halAdjustableBrightness) {
+            prefSet.removePreference(prefSet.findPreference(BRIGHTNESS_SECTION));
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        refreshColors();
+    }
+
+    private void refreshColors() {
+        ContentResolver resolver = getActivity().getContentResolver();
+        Resources res = getResources();
+
+        if (mLowColorPref != null) {
+            int lowColor = Settings.System.getInt(resolver,
+                    Settings.System.BATTERY_LIGHT_LOW_COLOR, mDefaultLowColor);
+            mLowColorPref.setAllValues(lowColor, 0, 0, false);
+        }
+
+        if (mMediumColorPref != null) {
+            int mediumColor = Settings.System.getInt(resolver,
+                    Settings.System.BATTERY_LIGHT_MEDIUM_COLOR, mDefaultMediumColor);
+            mMediumColorPref.setAllValues(mediumColor, 0, 0, false);
+        }
+
+        if (mFullColorPref != null) {
+            int fullColor = Settings.System.getInt(resolver,
+                    Settings.System.BATTERY_LIGHT_FULL_COLOR, mDefaultFullColor);
+            mFullColorPref.setAllValues(fullColor, 0, 0, false);
+            updateBrightnessPrefColor(fullColor);
+        }
+    }
+
+    private void updateBrightnessPrefColor(int color) {
+        // If the user has selected no light (ie black) for
+        // full charge, use white for the brightness preference.
+        if (color == 0) {
+            color = 0xFFFFFF;
+        }
+        mBatteryBrightnessPref.setLedColor(color);
+        mBatteryBrightnessZenPref.setLedColor(color);
+    }
+
+    /**
+     * Updates the default or application specific notification settings.
+     *
+     * @param key of the specific setting to update
+     */
+    protected void updateValues(String key, Integer color) {
+        ContentResolver resolver = getActivity().getContentResolver();
+
+        if (key.equals(LOW_COLOR_PREF)) {
+            Settings.System.putInt(resolver,
+                    Settings.System.BATTERY_LIGHT_LOW_COLOR, color);
+        } else if (key.equals(MEDIUM_COLOR_PREF)) {
+            Settings.System.putInt(resolver,
+                    Settings.System.BATTERY_LIGHT_MEDIUM_COLOR, color);
+        } else if (key.equals(FULL_COLOR_PREF)) {
+            Settings.System.putInt(resolver,
+                    Settings.System.BATTERY_LIGHT_FULL_COLOR, color);
+            updateBrightnessPrefColor(color);
+        }
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        if (mMultiColorLed) {
+            menu.add(0, MENU_RESET, 0, R.string.reset)
+                    .setIcon(R.drawable.ic_settings_backup_restore)
+                    .setAlphabeticShortcut('r')
+                    .setShowAsActionFlags(
+                            MenuItem.SHOW_AS_ACTION_ALWAYS | MenuItem.SHOW_AS_ACTION_WITH_TEXT);
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case MENU_RESET:
+                resetToDefaults();
+                return true;
+        }
+        return false;
+    }
+
+    protected void resetColors() {
+        ContentResolver resolver = getActivity().getContentResolver();
+
+        // Reset to the framework default colors
+        Settings.System.putInt(resolver, Settings.System.BATTERY_LIGHT_LOW_COLOR,
+                mDefaultLowColor);
+        Settings.System.putInt(resolver, Settings.System.BATTERY_LIGHT_MEDIUM_COLOR,
+                mDefaultMediumColor);
+        Settings.System.putInt(resolver, Settings.System.BATTERY_LIGHT_FULL_COLOR,
+                mDefaultFullColor);
+        refreshColors();
+    }
+
+    protected void resetToDefaults() {
+        final Resources res = getResources();
+        final boolean batteryLightEnabled = res.getBoolean(R.bool.def_battery_light_enabled);
+        final boolean batteryLightFullChargeDisabled =
+                res.getBoolean(R.bool.def_battery_light_full_charge_disabled);
+        final boolean batteryLightPulseEnabled = res.getBoolean(R.bool.def_battery_light_pulse);
+
+        if (mLightEnabledPref != null) mLightEnabledPref.setChecked(batteryLightEnabled);
+        if (mLightFullChargeDisabledPref != null) {
+            mLightFullChargeDisabledPref.setChecked(batteryLightFullChargeDisabled);
+        }
+        if (mPulseEnabledPref != null) mPulseEnabledPref.setChecked(batteryLightPulseEnabled);
+
+        resetColors();
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object objValue) {
+        ApplicationLightPreference lightPref = (ApplicationLightPreference) preference;
+        updateValues(lightPref.getKey(), lightPref.getColor());
+        return true;
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsEvent.EVO_SETTINGS;
+    }
+
+    @Override
+    public void onDisplayPreferenceDialog(Preference preference) {
+        if (preference.getKey() == null) {
+            // Auto-key preferences that don't have a key, so the dialog can find them.
+            preference.setKey(UUID.randomUUID().toString());
+        }
+        DialogFragment f = null;
+        if (preference instanceof CustomDialogPreference) {
+            f = CustomDialogPreference.CustomPreferenceDialogFragment
+                    .newInstance(preference.getKey());
+        } else {
+            super.onDisplayPreferenceDialog(preference);
+            return;
+        }
+        f.setTargetFragment(this, 0);
+        f.show(getFragmentManager(), "dialog_preference");
+        onDialogShowing();
+    }
+}

--- a/src/com/android/settings/evolution/notificationlight/BrightnessPreference.java
+++ b/src/com/android/settings/evolution/notificationlight/BrightnessPreference.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (C) 2017,2019-2022 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.evolution.notificationlight;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.provider.Settings;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.SeekBar;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
+
+import com.android.internal.evolution.notification.LightsCapabilities;
+import com.android.internal.evolution.notification.LineageNotification;
+import com.evolution.settings.preference.CustomDialogPreference;
+import com.android.settings.R;
+
+public class BrightnessPreference extends CustomDialogPreference<AlertDialog>
+        implements SeekBar.OnSeekBarChangeListener {
+
+    private static final String TAG = "BrightnessPreference";
+
+    public static final int LIGHT_BRIGHTNESS_MINIMUM = 1;
+    public static final int LIGHT_BRIGHTNESS_MAXIMUM = 255;
+
+    // Minimum delay between LED notification updates
+    private final static long LED_UPDATE_DELAY_MS = 250;
+
+    // Default led color used to illustrate brightness
+    private final static int DEFAULT_LED_COLOR = 0xFFFFFF;
+
+    private TextView mPreferencePercent;
+
+    private TextView mDialogPercent;
+    private SeekBar mBrightnessBar;
+
+    // The user selected brightness level (past or present if dialog is OKed).
+    private int mSelectedBrightness;
+    // Current position of brightness seekbar
+    private int mSeekBarBrightness;
+    // LED brightness currently on display (0 means notification is not showing)
+    private int mVisibleLedBrightness;
+    // LED color used to illustrate brightness
+    private int mLedColor = DEFAULT_LED_COLOR;
+
+    private final Context mContext;
+
+    private final Notification.Builder mNotificationBuilder;
+    private final NotificationManager mNotificationManager;
+
+    public interface OnBrightnessChangedListener {
+        void onBrightnessChanged(int brightness);
+    }
+
+    private OnBrightnessChangedListener mListener;
+
+    public BrightnessPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+
+        setWidgetLayoutResource(R.layout.preference_brightness);
+        setDialogLayoutResource(R.layout.dialog_brightness);
+
+        mContext = context;
+
+        mNotificationManager = context.getSystemService(NotificationManager.class);
+
+        // Force lights on when screen is on and also force maximum brightness.
+        Bundle bundle = new Bundle();
+        bundle.putBoolean(LineageNotification.EXTRA_FORCE_SHOW_LIGHTS, true);
+        bundle.putInt(LineageNotification.EXTRA_FORCE_LIGHT_BRIGHTNESS, LIGHT_BRIGHTNESS_MAXIMUM);
+
+        mNotificationBuilder = new Notification.Builder(mContext);
+        mNotificationBuilder.setExtras(bundle)
+                .setContentTitle(mContext.getString(R.string.led_notification_title))
+                .setContentText(mContext.getString(R.string.led_notification_text))
+                .setSmallIcon(R.drawable.ic_settings_24dp)
+                .setOngoing(true);
+    }
+
+    @Override
+    public void onBindViewHolder(PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+
+        mSelectedBrightness = getBrightnessSetting();
+        mSeekBarBrightness = mSelectedBrightness;
+
+        mPreferencePercent = (TextView) holder.findViewById(R.id.brightness_percent);
+        mPreferencePercent.setText(percentString(mSelectedBrightness, LIGHT_BRIGHTNESS_MINIMUM,
+                LIGHT_BRIGHTNESS_MAXIMUM));
+    }
+
+    @Override
+    protected void onPrepareDialogBuilder(AlertDialog.Builder builder,
+            DialogInterface.OnClickListener listener) {
+        super.onPrepareDialogBuilder(builder, listener);
+        builder.setNeutralButton(R.string.reset, null);
+        builder.setNegativeButton(R.string.cancel, null);
+        builder.setPositiveButton(R.string.dlg_ok, null);
+    }
+
+    @Override
+    protected boolean onDismissDialog(AlertDialog dialog, int which) {
+        if (which == DialogInterface.BUTTON_NEUTRAL) {
+            // Reset brightness to default (max).
+            mBrightnessBar.setProgress(LIGHT_BRIGHTNESS_MAXIMUM);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    protected void onDialogClosed(boolean positiveResult) {
+        super.onDialogClosed(positiveResult);
+
+        if (positiveResult) {
+            mSelectedBrightness = mSeekBarBrightness;
+            setBrightnessSetting(mSelectedBrightness);
+            if (mListener != null) {
+                mListener.onBrightnessChanged(mSelectedBrightness);
+            }
+            mPreferencePercent.setText(percentString(mSelectedBrightness,
+                    LIGHT_BRIGHTNESS_MINIMUM, LIGHT_BRIGHTNESS_MAXIMUM));
+        } else {
+            mSeekBarBrightness = mSelectedBrightness;
+        }
+    }
+
+    @Override
+    protected void onBindDialogView(View view) {
+        super.onBindDialogView(view);
+
+        // Locate text view for percentage value
+        mDialogPercent = view.findViewById(R.id.brightness_percent);
+
+        mVisibleLedBrightness = 0; // LED notification is not showing.
+
+        mBrightnessBar = view.findViewById(R.id.brightness_seekbar);
+        mBrightnessBar.setMax(LIGHT_BRIGHTNESS_MAXIMUM);
+        mBrightnessBar.setMin(LIGHT_BRIGHTNESS_MINIMUM);
+        mBrightnessBar.setOnSeekBarChangeListener(this);
+        mBrightnessBar.setProgress(mSeekBarBrightness);
+        mBrightnessBar.setThumb(mContext.getResources().getDrawable(
+                R.drawable.ic_brightness_thumb, mContext.getTheme()));
+    }
+
+    @Override
+    protected void onResume() {
+        updateNotification();
+    }
+
+    @Override
+    protected void onPause() {
+        cancelNotification();
+    }
+
+    @Override
+    public void onStartTrackingTouch (SeekBar seekBar) {}
+
+    @Override
+    public void onStopTrackingTouch (SeekBar seekBar) {}
+
+    @Override
+    public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+        mSeekBarBrightness = progress;
+        updateNotification();
+        mDialogPercent.setText(percentString(progress, seekBar.getMin(), seekBar.getMax()));
+    }
+
+    public void setOnBrightnessChangedListener(OnBrightnessChangedListener listener) {
+        mListener = listener;
+    }
+
+    protected int getBrightnessSetting() {
+        // Null implementation
+        return LIGHT_BRIGHTNESS_MAXIMUM;
+    }
+
+    protected void setBrightnessSetting(int brightness) {
+        // Null implementation
+    }
+
+    public void setLedColor(int color) {
+        mLedColor = color & 0xFFFFFF;
+    }
+
+    private void updateNotification() {
+        // Exit if there's nothing to do or we're throttled.
+        if (mVisibleLedBrightness == mSeekBarBrightness || mLedHandler.hasMessages(0)) {
+            return;
+        }
+
+        mLedHandler.sendEmptyMessageDelayed(0, LED_UPDATE_DELAY_MS);
+
+        // Instead of canceling the notification, force it to update with the color.
+        // Use a white light for a better preview of the brightness.
+        int notificationColor = mLedColor | (mSeekBarBrightness << 24);
+        mNotificationBuilder.setLights(notificationColor, 1, 0);
+        mNotificationManager.notify(1, mNotificationBuilder.build());
+        mVisibleLedBrightness = mSeekBarBrightness;
+    }
+
+    private void cancelNotification() {
+        if (mVisibleLedBrightness > 0) {
+            mLedHandler.removeMessages(0);
+            mNotificationManager.cancel(1);
+            mVisibleLedBrightness = 0;
+        }
+    }
+
+    private final Handler mLedHandler = new Handler(Looper.getMainLooper()) {
+        public void handleMessage(Message msg) {
+            updateNotification();
+        }
+    };
+
+    @Override
+    protected Parcelable onSaveInstanceState() {
+        final Parcelable superState = super.onSaveInstanceState();
+        if (getDialog() == null || !getDialog().isShowing()) {
+            return superState;
+        }
+
+        // Save the dialog state
+        final SavedState myState = new SavedState(superState);
+        myState.seekBarBrightness = mSeekBarBrightness;
+
+        return myState;
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Parcelable state) {
+        if (state == null || !state.getClass().equals(SavedState.class)) {
+            // Didn't save state for us in onSaveInstanceState
+            super.onRestoreInstanceState(state);
+            return;
+        }
+
+        SavedState myState = (SavedState) state;
+        super.onRestoreInstanceState(myState.getSuperState());
+
+        mSeekBarBrightness = myState.seekBarBrightness;
+    }
+
+    private String percentString(int progress, int min, int max) {
+        final float percentage = 100f * (progress - min ) / (max - min);
+        return String.format("%d%%", Math.round(percentage));
+    }
+
+    private static class SavedState extends BaseSavedState {
+        int seekBarBrightness;
+
+        public SavedState(Parcelable superState) {
+            super(superState);
+        }
+
+        public SavedState(Parcel source) {
+            super(source);
+            seekBarBrightness = source.readInt();
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            super.writeToParcel(dest, flags);
+            dest.writeInt(seekBarBrightness);
+        }
+
+        public static final Parcelable.Creator<SavedState> CREATOR = new Parcelable.Creator<>() {
+            public SavedState createFromParcel(Parcel in) {
+                return new SavedState(in);
+            }
+
+            public SavedState[] newArray(int size) {
+                return new SavedState[size];
+            }
+        };
+    }
+}

--- a/src/com/android/settings/evolution/notificationlight/LightSettingsDialog.java
+++ b/src/com/android/settings/evolution/notificationlight/LightSettingsDialog.java
@@ -1,0 +1,473 @@
+/*
+ * Copyright (C) 2010 Daniel Nilsson
+ * Copyright (C) 2012 The CyanogenMod Project
+ *               2017,2019-2022 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.evolution.notificationlight;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.PixelFormat;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.text.InputFilter;
+import android.util.Pair;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.View.OnFocusChangeListener;
+import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.AdapterView;
+import android.widget.BaseAdapter;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.Spinner;
+import android.widget.SpinnerAdapter;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AlertDialog;
+
+import com.android.internal.evolution.notification.LedValues;
+import com.android.internal.evolution.notification.LightsCapabilities;
+import com.android.internal.evolution.notification.LineageNotification;
+import com.android.settings.R;
+
+import com.evolution.settings.preference.colorpicker.ColorPanelView;
+import com.evolution.settings.preference.colorpicker.ColorPickerView;
+
+import java.util.ArrayList;
+import java.util.Locale;
+
+public class LightSettingsDialog extends AlertDialog implements
+        ColorPickerView.OnColorChangedListener, TextWatcher, OnFocusChangeListener {
+
+    private final static String STATE_KEY_COLOR = "LightSettingsDialog:color";
+    // Minimum delay between LED notification updates
+    private final static long LED_UPDATE_DELAY_MS = 250;
+
+    private ColorPickerView mColorPicker;
+
+    private EditText mHexColorInput;
+    private ColorPanelView mNewColor;
+    private PulseSpeedAdapter mPulseSpeedAdapterOn;
+    private PulseSpeedAdapter mPulseSpeedAdapterOff;
+    private Spinner mPulseSpeedOn;
+    private Spinner mPulseSpeedOff;
+    private LayoutInflater mInflater;
+
+    private NotificationManager mNotificationManager;
+
+    private boolean mReadyForLed;
+    private int mLedLastColor;
+    private int mLedLastSpeedOn;
+    private int mLedLastSpeedOff;
+
+    private int mLedBrightness;
+    private int mLedLastBrightness;
+
+    private Context mContext;
+
+    protected LightSettingsDialog(Context context, int initialColor, int initialSpeedOn,
+            int initialSpeedOff) {
+        super(context);
+
+        init(context, initialColor, initialSpeedOn, initialSpeedOff, true, 0);
+    }
+
+    protected LightSettingsDialog(Context context, int initialColor, int initialSpeedOn,
+            int initialSpeedOff, boolean onOffChangeable, int brightness) {
+        super(context);
+
+        init(context, initialColor, initialSpeedOn, initialSpeedOff, onOffChangeable, brightness);
+    }
+
+    private void init(Context context, int color, int speedOn, int speedOff,
+            boolean onOffChangeable, int brightness) {
+        mContext = context;
+        mNotificationManager = mContext.getSystemService(NotificationManager.class);
+
+        mReadyForLed = false;
+        mLedLastColor = 0;
+
+        // To fight color banding.
+        getWindow().setFormat(PixelFormat.RGBA_8888);
+        setUp(color, speedOn, speedOff, onOffChangeable, brightness);
+    }
+
+    /**
+     * This function sets up the dialog with the proper values.  If the speedOff parameters
+     * has a -1 value disable both spinners
+     *
+     * @param color - the color to set
+     * @param speedOn - the flash time in ms
+     * @param speedOff - the flash length in ms
+     */
+    private void setUp(int color, int speedOn, int speedOff, boolean onOffChangeable,
+               int brightness) {
+        mInflater = mContext.getSystemService(LayoutInflater.class);
+        View layout = mInflater.inflate(R.layout.dialog_light_settings, null);
+
+        mColorPicker = layout.findViewById(R.id.color_picker_view);
+        mHexColorInput = layout.findViewById(R.id.hex_color_input);
+        mNewColor = layout.findViewById(R.id.color_panel);
+        mPulseSpeedOn = layout.findViewById(R.id.on_spinner);
+        mPulseSpeedOff = layout.findViewById(R.id.off_spinner);
+        mColorPicker.setOnColorChangedListener(this);
+        mColorPicker.setColor(color, true);
+
+        mHexColorInput.setOnFocusChangeListener(this);
+
+        if (onOffChangeable) {
+            mPulseSpeedAdapterOn = new PulseSpeedAdapter(
+                    R.array.notification_pulse_length_entries,
+                    R.array.notification_pulse_length_values,
+                    speedOn);
+            mPulseSpeedOn.setAdapter(mPulseSpeedAdapterOn);
+            mPulseSpeedOn.setSelection(mPulseSpeedAdapterOn.getTimePosition(speedOn));
+            mPulseSpeedOn.setOnItemSelectedListener(mPulseSelectionListener);
+
+            mPulseSpeedAdapterOff = new PulseSpeedAdapter(R.array.notification_pulse_speed_entries,
+                    R.array.notification_pulse_speed_values,
+                    speedOff);
+            mPulseSpeedOff.setAdapter(mPulseSpeedAdapterOff);
+            mPulseSpeedOff.setSelection(mPulseSpeedAdapterOff.getTimePosition(speedOff));
+            mPulseSpeedOff.setOnItemSelectedListener(mPulseSelectionListener);
+        } else {
+            View speedSettingsGroup = layout.findViewById(R.id.speed_title_view);
+            speedSettingsGroup.setVisibility(View.GONE);
+        }
+
+        mPulseSpeedOn.setEnabled(onOffChangeable);
+        mPulseSpeedOff.setEnabled((speedOn != 1) && onOffChangeable);
+
+        setView(layout);
+        setTitle(R.string.edit_light_settings);
+
+        if (!LightsCapabilities.supports(
+                mContext, LightsCapabilities.LIGHTS_RGB_NOTIFICATION_LED)) {
+            mColorPicker.setVisibility(View.GONE);
+            LinearLayout colorPanel = layout.findViewById(R.id.color_panel_view);
+            colorPanel.setVisibility(View.GONE);
+            View lightsDialogDivider = layout.findViewById(R.id.lights_dialog_divider);
+            lightsDialogDivider.setVisibility(View.GONE);
+        }
+
+        mLedBrightness = brightness;
+        mLedLastBrightness = -1; // out of range
+
+        mReadyForLed = true;
+        updateLed();
+    }
+
+    private final AdapterView.OnItemSelectedListener mPulseSelectionListener =
+            new AdapterView.OnItemSelectedListener() {
+        @Override
+        public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+            if (parent == mPulseSpeedOn) {
+                mPulseSpeedOff.setEnabled(mPulseSpeedOn.isEnabled() && getPulseSpeedOn() != 1);
+            }
+            updateLed();
+        }
+
+        @Override
+        public void onNothingSelected(AdapterView<?> parent) {
+        }
+    };
+
+    @Override
+    public Bundle onSaveInstanceState() {
+        Bundle state = super.onSaveInstanceState();
+        state.putInt(STATE_KEY_COLOR, getColor());
+        return state;
+    }
+
+    @Override
+    public void onRestoreInstanceState(Bundle state) {
+        super.onRestoreInstanceState(state);
+        mColorPicker.setColor(state.getInt(STATE_KEY_COLOR), true);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        dismissLed();
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        updateLed();
+    }
+
+    @Override
+    public void onColorChanged(int color) {
+        final boolean hasAlpha = mColorPicker.isAlphaSliderVisible();
+        final String format = hasAlpha ? "%08x" : "%06x";
+        final int mask = hasAlpha ? 0xFFFFFFFF : 0x00FFFFFF;
+
+        mNewColor.setColor(color);
+        mHexColorInput.setText(String.format(Locale.US, format, color & mask));
+
+        updateLed();
+    }
+
+    public void setAlphaSliderVisible(boolean visible) {
+        mHexColorInput.setFilters(new InputFilter[] {
+                new InputFilter.LengthFilter(visible ? 8 : 6) } );
+        mColorPicker.setAlphaSliderVisible(visible);
+    }
+
+    public int getColor() {
+        return mColorPicker.getColor();
+    }
+
+    public void setColor(int color) {
+        mColorPicker.setColor(color, true);
+    }
+
+    @SuppressWarnings("unchecked")
+    public int getPulseSpeedOn() {
+        if (mPulseSpeedOn.isEnabled()) {
+            return ((Pair<String, Integer>) mPulseSpeedOn.getSelectedItem()).second;
+        } else {
+            return 1;
+        }
+    }
+
+    public void setPulseSpeedOn(int speedOn) {
+        mPulseSpeedOn.setSelection(mPulseSpeedAdapterOn.getTimePosition(speedOn));
+    }
+
+    @SuppressWarnings("unchecked")
+    public int getPulseSpeedOff() {
+        // return 0 if 'Always on' is selected
+        return getPulseSpeedOn() == 1
+                ? 0
+                : ((Pair<String, Integer>) mPulseSpeedOff.getSelectedItem()).second;    }
+
+    public void setPulseSpeedOff(int speedOff) {
+        mPulseSpeedOff.setSelection(mPulseSpeedAdapterOff.getTimePosition(speedOff));
+    }
+
+    private final Handler mLedHandler = new Handler(Looper.getMainLooper()) {
+        public void handleMessage(Message msg) {
+            updateLed();
+        }
+    };
+
+    private void updateLed() {
+        if (!mReadyForLed) {
+            return;
+        }
+
+        final int color = getColor() & 0xFFFFFF;
+        final int speedOn, speedOff;
+        if (mPulseSpeedOn.isEnabled()) {
+            speedOn = getPulseSpeedOn();
+            speedOff = getPulseSpeedOff();
+        } else {
+            speedOn = 1;
+            speedOff = 0;
+        }
+
+        if (mLedLastColor == color && mLedLastSpeedOn == speedOn && mLedLastSpeedOff == speedOff
+                && mLedLastBrightness == mLedBrightness) {
+            return;
+        }
+
+        // Dampen rate of consecutive LED changes
+        if (mLedHandler.hasMessages(0)) {
+            return;
+        }
+        mLedHandler.sendEmptyMessageDelayed(0, LED_UPDATE_DELAY_MS);
+
+        // Set a notification to display the LED color
+        final Bundle b = new Bundle();
+        b.putBoolean(LineageNotification.EXTRA_FORCE_SHOW_LIGHTS, true);
+        if  (mLedBrightness > 0 && mLedBrightness < LedValues.LIGHT_BRIGHTNESS_MAXIMUM) {
+            b.putInt(LineageNotification.EXTRA_FORCE_LIGHT_BRIGHTNESS, mLedBrightness);
+        }
+        b.putInt(LineageNotification.EXTRA_FORCE_COLOR, color);
+        b.putInt(LineageNotification.EXTRA_FORCE_LIGHT_ON_MS, speedOn);
+        b.putInt(LineageNotification.EXTRA_FORCE_LIGHT_OFF_MS, speedOff);
+
+        createNotificationChannel();
+
+        final String channelId = mContext.getString(R.string.channel_light_settings_id);
+        final Notification.Builder builder = new Notification.Builder(mContext, channelId);
+        builder.setLights(color, speedOn, speedOff);
+        builder.setExtras(b);
+        builder.setSmallIcon(R.drawable.ic_settings_24dp);
+        builder.setContentTitle(mContext.getString(R.string.led_notification_title));
+        builder.setContentText(mContext.getString(R.string.led_notification_text));
+        builder.setOngoing(true);
+
+        final Notification notification = builder.build();
+        mNotificationManager.notify(channelId, 1, notification);
+
+        mLedLastColor = color;
+        mLedLastSpeedOn = speedOn;
+        mLedLastSpeedOff = speedOff;
+        mLedLastBrightness = mLedBrightness;
+    }
+
+    public void dismissLed() {
+        final String channelId = mContext.getString(R.string.channel_light_settings_id);
+        mNotificationManager.cancel(channelId, 1);
+        // ensure we later reset LED if dialog is
+        // hidden and then made visible
+        mLedLastColor = 0;
+    }
+
+    private void createNotificationChannel() {
+        final String channelId = mContext.getString(R.string.channel_light_settings_id);
+        final String channelName = mContext.getString(R.string.channel_light_settings_name);
+        final NotificationChannel notificationChannel = new NotificationChannel(
+                channelId, channelName, NotificationManager.IMPORTANCE_LOW);
+        notificationChannel.enableLights(true);
+        notificationChannel.enableVibration(false);
+        notificationChannel.setShowBadge(false);
+
+        mNotificationManager.createNotificationChannel(notificationChannel);
+    }
+
+    class PulseSpeedAdapter extends BaseAdapter implements SpinnerAdapter {
+        private final ArrayList<Pair<String, Integer>> times;
+
+        public PulseSpeedAdapter(int timeNamesResource, int timeValuesResource) {
+            times = new ArrayList<>();
+
+            String[] time_names = mContext.getResources().getStringArray(timeNamesResource);
+            String[] time_values = mContext.getResources().getStringArray(timeValuesResource);
+
+            for(int i = 0; i < time_values.length; ++i) {
+                times.add(new Pair<>(time_names[i], Integer.decode(time_values[i])));
+            }
+
+        }
+
+        /**
+         * This constructor apart from taking a usual time entry array takes the
+         * currently configured time value which might cause the addition of a
+         * "Custom" time entry in the spinner in case this time value does not
+         * match any of the predefined ones in the array.
+         *
+         * @param timeNamesResource The time entry names array
+         * @param timeValuesResource The time entry values array
+         * @param customTime Current time value that might be one of the
+         *            predefined values or a totally custom value
+         */
+        public PulseSpeedAdapter(int timeNamesResource, int timeValuesResource,
+                                 Integer customTime) {
+            this(timeNamesResource, timeValuesResource);
+
+            // Check if we also need to add the custom value entry
+            if (getTimePosition(customTime) == -1) {
+                times.add(new Pair<String, Integer>(mContext.getResources()
+                        .getString(R.string.custom_time), customTime));
+            }
+        }
+
+        /**
+         * Will return the position of the spinner entry with the specified
+         * time. Returns -1 if there is no such entry.
+         *
+         * @param time Time in ms
+         * @return Position of entry with given time or -1 if not found.
+         */
+        public int getTimePosition(Integer time) {
+            for (int position = 0; position < getCount(); ++position) {
+                if (getItem(position).second.equals(time)) {
+                    return position;
+                }
+            }
+
+            return -1;
+        }
+
+        @Override
+        public int getCount() {
+            return times.size();
+        }
+
+        @Override
+        public Pair<String, Integer> getItem(int position) {
+            return times.get(position);
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(int position, View view, ViewGroup parent) {
+            if (view == null) {
+                view = mInflater.inflate(R.layout.pulse_time_item, parent, false);
+            }
+
+            Pair<String, Integer> entry = getItem(position);
+            ((TextView) view.findViewById(R.id.textViewName)).setText(entry.first);
+
+            return view;
+        }
+    }
+
+    @Override
+    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+    }
+
+    @Override
+    public void onTextChanged(CharSequence s, int start, int before, int count) {
+    }
+
+    @Override
+    public void afterTextChanged(Editable s) {
+        String hexColor = mHexColorInput.getText().toString();
+        if (!hexColor.isEmpty()) {
+            try {
+                int color = Color.parseColor('#' + hexColor);
+                if (!mColorPicker.isAlphaSliderVisible()) {
+                    color |= 0xFF000000; // set opaque
+                }
+                mColorPicker.setColor(color);
+                mNewColor.setColor(color);
+                updateLed();
+            } catch (IllegalArgumentException ex) {
+                // Number format is incorrect, ignore
+            }
+        }
+    }
+
+    @Override
+    public void onFocusChange(View v, boolean hasFocus) {
+        if (!hasFocus) {
+            mHexColorInput.removeTextChangedListener(this);
+            InputMethodManager inputMethodManager =
+                    mContext.getSystemService(InputMethodManager.class);
+            inputMethodManager.hideSoftInputFromWindow(v.getWindowToken(), 0);
+        } else {
+            mHexColorInput.addTextChangedListener(this);
+        }
+    }
+}

--- a/src/com/android/settings/evolution/notificationlight/NotificationBrightnessPreference.java
+++ b/src/com/android/settings/evolution/notificationlight/NotificationBrightnessPreference.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017-2022 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.evolution.notificationlight;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.os.UserHandle;
+import android.provider.Settings;
+import android.util.AttributeSet;
+
+public class NotificationBrightnessPreference extends BrightnessPreference {
+    private static final String TAG = "NotificationBrightnessPreference";
+
+    private final ContentResolver mResolver;
+
+    public NotificationBrightnessPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        mResolver = context.getContentResolver();
+    }
+
+    @Override
+    protected int getBrightnessSetting() {
+        return Settings.System.getIntForUser(mResolver,
+                Settings.System.NOTIFICATION_LIGHT_BRIGHTNESS_LEVEL,
+                LIGHT_BRIGHTNESS_MAXIMUM, UserHandle.USER_CURRENT);
+    }
+
+    @Override
+    protected void setBrightnessSetting(int brightness) {
+        Settings.System.putIntForUser(mResolver,
+                Settings.System.NOTIFICATION_LIGHT_BRIGHTNESS_LEVEL,
+                brightness, UserHandle.USER_CURRENT);
+    }
+}

--- a/src/com/android/settings/evolution/notificationlight/NotificationBrightnessZenPreference.java
+++ b/src/com/android/settings/evolution/notificationlight/NotificationBrightnessZenPreference.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017-2022 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.evolution.notificationlight;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.os.UserHandle;
+import android.provider.Settings;
+import android.util.AttributeSet;
+
+public class NotificationBrightnessZenPreference extends BrightnessPreference {
+    private static final String TAG = "NotificationBrightnessZenPreference";
+
+    private final ContentResolver mResolver;
+
+    public NotificationBrightnessZenPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        mResolver = context.getContentResolver();
+    }
+
+    @Override
+    protected int getBrightnessSetting() {
+        return Settings.System.getIntForUser(mResolver,
+                Settings.System.NOTIFICATION_LIGHT_BRIGHTNESS_LEVEL_ZEN,
+                LIGHT_BRIGHTNESS_MAXIMUM, UserHandle.USER_CURRENT);
+    }
+
+    @Override
+    protected void setBrightnessSetting(int brightness) {
+        Settings.System.putIntForUser(mResolver,
+                Settings.System.NOTIFICATION_LIGHT_BRIGHTNESS_LEVEL_ZEN,
+                brightness, UserHandle.USER_CURRENT);
+    }
+}

--- a/src/com/android/settings/evolution/notificationlight/NotificationLightPreferenceController.java
+++ b/src/com/android/settings/evolution/notificationlight/NotificationLightPreferenceController.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 The PixelExperience Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.evolution.notificationlight;
+
+import android.content.Context;
+import com.android.settings.core.BasePreferenceController;
+
+public class NotificationLightPreferenceController extends BasePreferenceController {
+
+    public static final String KEY = "notification_lights";
+
+    private Context mContext;
+
+    public NotificationLightPreferenceController(Context context, String key) {
+        super(context, key);
+
+        mContext = context;
+    }
+
+    public NotificationLightPreferenceController(Context context) {
+        this(context, KEY);
+
+        mContext = context;
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        boolean exists = mContext.getResources().getBoolean(com.android.internal.R.bool.config_intrusiveNotificationLed);
+        return (exists ? AVAILABLE : UNSUPPORTED_ON_DEVICE);
+    }
+
+}

--- a/src/com/android/settings/evolution/notificationlight/NotificationLightSettings.java
+++ b/src/com/android/settings/evolution/notificationlight/NotificationLightSettings.java
@@ -1,0 +1,640 @@
+/*
+ * Copyright (C) 2012 The CyanogenMod Project
+ *               2017-2022 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.evolution.notificationlight;
+
+import android.app.Dialog;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.telephony.TelephonyManager;
+import android.text.TextUtils;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ListView;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceGroup;
+import androidx.preference.PreferenceScreen;
+
+import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
+import com.android.internal.evolution.notification.LightsCapabilities;
+import com.evolution.settings.preference.CustomDialogPreference;
+import com.evolution.settings.preference.PackageListAdapter;
+import com.evolution.settings.preference.PackageListAdapter.PackageItem;
+import com.android.settings.R;
+import com.android.settings.SettingsPreferenceFragment;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.evolution.settings.preference.SystemSettingSwitchPreference;
+import com.evolution.settings.preference.SystemSettingMainSwitchPreference;
+import com.android.internal.util.evolution.ColorUtils;
+
+public class NotificationLightSettings extends SettingsPreferenceFragment implements
+        Preference.OnPreferenceChangeListener, ApplicationLightPreference.ItemLongClickListener {
+    private static final String TAG = "NotificationLightSettings";
+
+    private static final String KEY_NOTIFICATION_LIGHTS = "notification_lights";
+    private static final String NOTIFICATION_LIGHT_PULSE =
+            Settings.System.NOTIFICATION_LIGHT_PULSE;
+    private static final String NOTIFICATION_LIGHT_COLOR_AUTO =
+            Settings.System.NOTIFICATION_LIGHT_COLOR_AUTO;
+    private static final String NOTIFICATION_LIGHT_SCREEN_ON =
+            Settings.System.NOTIFICATION_LIGHT_SCREEN_ON;
+    private static final String NOTIFICATION_LIGHT_PULSE_CUSTOM_ENABLE =
+            Settings.System.NOTIFICATION_LIGHT_PULSE_CUSTOM_ENABLE;
+    private static final String NOTIFICATION_LIGHT_BRIGHTNESS_LEVEL =
+            Settings.System.NOTIFICATION_LIGHT_BRIGHTNESS_LEVEL;
+    private static final String NOTIFICATION_LIGHT_BRIGHTNESS_LEVEL_ZEN =
+            Settings.System.NOTIFICATION_LIGHT_BRIGHTNESS_LEVEL_ZEN;
+
+    private static final String ADVANCED_SECTION = "advanced_section";
+    private static final String APPLICATION_SECTION = "applications_list";
+    private static final String BRIGHTNESS_SECTION = "brightness_section";
+    private static final String GENERAL_SECTION = "general_section";
+    private static final String PHONE_SECTION = "phone_list";
+
+    private static final String DEFAULT_PREF = "default";
+    private static final String MISSED_CALL_PREF = "missed_call";
+    private static final String VOICEMAIL_PREF = "voicemail";
+    private static final String ADD_APPS = "custom_apps_add";
+
+    public static final int ACTION_TEST = 0;
+    public static final int ACTION_DELETE = 1;
+    private static final int DIALOG_APPS = 0;
+
+    private int mDefaultColor;
+    private int mDefaultLedOn;
+    private int mDefaultLedOff;
+    private PackageManager mPackageManager;
+    private PreferenceGroup mApplicationPrefList;
+    private SystemSettingMainSwitchPreference mEnabledPref;
+    private SystemSettingSwitchPreference mCustomEnabledPref;
+    private SystemSettingSwitchPreference mScreenOnLightsPref;
+    private SystemSettingSwitchPreference mAutoGenerateColors;
+    private ApplicationLightPreference mDefaultPref;
+    private ApplicationLightPreference mCallPref;
+    private ApplicationLightPreference mVoicemailPref;
+    private PackageListAdapter mPackageAdapter;
+    private String mPackageList;
+    private Map<String, Package> mPackages;
+    // Supports rgb color control
+    private boolean mMultiColorLed;
+    // Supports adjustable pulse
+    private boolean mLedCanPulse;
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        final Context context = getContext();
+
+        addPreferencesFromResource(R.xml.notification_light_settings);
+        getActivity().getActionBar().setTitle(R.string.notification_light_title);
+
+        PreferenceScreen prefSet = getPreferenceScreen();
+        Resources resources = getResources();
+
+        PreferenceGroup mAdvancedPrefs = prefSet.findPreference(ADVANCED_SECTION);
+        PreferenceGroup mGeneralPrefs = prefSet.findPreference(GENERAL_SECTION);
+
+        // Get the system defined default notification color
+        mDefaultColor = resources.getColor(
+                com.android.internal.R.color.config_defaultNotificationColor, null);
+
+        mDefaultLedOn = resources.getInteger(
+                com.android.internal.R.integer.config_defaultNotificationLedOn);
+        mDefaultLedOff = resources.getInteger(
+                com.android.internal.R.integer.config_defaultNotificationLedOff);
+
+        // liblights supports brightness control
+        final boolean halAdjustableBrightness = LightsCapabilities.supports(
+                context, LightsCapabilities.LIGHTS_ADJUSTABLE_NOTIFICATION_LED_BRIGHTNESS);
+        mLedCanPulse = LightsCapabilities.supports(
+                context, LightsCapabilities.LIGHTS_PULSATING_LED);
+        mMultiColorLed = LightsCapabilities.supports(
+                context, LightsCapabilities.LIGHTS_RGB_NOTIFICATION_LED);
+
+        mEnabledPref = findPreference(Settings.System.NOTIFICATION_LIGHT_PULSE);
+        mEnabledPref.setOnPreferenceChangeListener(this);
+
+        mDefaultPref = findPreference(DEFAULT_PREF);
+
+        mAutoGenerateColors = findPreference(Settings.System.NOTIFICATION_LIGHT_COLOR_AUTO);
+
+        // Advanced light settings
+        mScreenOnLightsPref =
+                findPreference(Settings.System.NOTIFICATION_LIGHT_SCREEN_ON);
+        mScreenOnLightsPref.setOnPreferenceChangeListener(this);
+        mCustomEnabledPref =
+                findPreference(Settings.System.NOTIFICATION_LIGHT_PULSE_CUSTOM_ENABLE);
+        if (!mMultiColorLed && !halAdjustableBrightness) {
+            removePreference(BRIGHTNESS_SECTION);
+        }
+        if (!mLedCanPulse && !mMultiColorLed) {
+            mGeneralPrefs.removePreference(mDefaultPref);
+            mAdvancedPrefs.removePreference(mCustomEnabledPref);
+        } else {
+            mCustomEnabledPref.setOnPreferenceChangeListener(this);
+            mDefaultPref.setOnPreferenceChangeListener(this);
+            mDefaultPref.setDefaultValues(mDefaultColor, mDefaultLedOn, mDefaultLedOff);
+        }
+
+        // Missed call and Voicemail preferences should only show on devices with voice capabilities
+        TelephonyManager tm = getActivity().getSystemService(TelephonyManager.class);
+        if (tm.getPhoneType() == TelephonyManager.PHONE_TYPE_NONE
+                || (!mLedCanPulse && !mMultiColorLed)) {
+            removePreference(PHONE_SECTION);
+        } else {
+            mCallPref = findPreference(MISSED_CALL_PREF);
+            mCallPref.setOnPreferenceChangeListener(this);
+            mCallPref.setDefaultValues(mDefaultColor, mDefaultLedOn, mDefaultLedOff);
+
+            mVoicemailPref = findPreference(VOICEMAIL_PREF);
+            mVoicemailPref.setOnPreferenceChangeListener(this);
+            mVoicemailPref.setDefaultValues(mDefaultColor, mDefaultLedOn, mDefaultLedOff);
+        }
+
+        if (!mLedCanPulse && !mMultiColorLed) {
+            removePreference(APPLICATION_SECTION);
+        } else {
+            mApplicationPrefList = findPreference(APPLICATION_SECTION);
+            mApplicationPrefList.setOrderingAsAdded(false);
+
+            // Get launch-able applications
+            mPackageManager = getActivity().getPackageManager();
+            mPackageAdapter = new PackageListAdapter(getActivity());
+
+            mPackages = new HashMap<>();
+
+            Preference addPreference = prefSet.findPreference(ADD_APPS);
+            addPreference.setOnPreferenceClickListener(preference -> {
+                showDialog(DIALOG_APPS);
+                return true;
+            });
+        }
+
+        // Get launch-able applications
+        mPackageManager = getActivity().getPackageManager();
+        mPackageAdapter = new PackageListAdapter(getActivity());
+
+        mPackages = new HashMap<String, Package>();
+
+        if (!mMultiColorLed) {
+            resetColors();
+            mGeneralPrefs.removePreference(mAutoGenerateColors);
+        } else {
+            mAutoGenerateColors.setOnPreferenceChangeListener(this);
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        refreshDefault();
+        refreshCustomApplicationPrefs();
+        getActivity().invalidateOptionsMenu();
+    }
+
+    private void refreshDefault() {
+        ContentResolver resolver = getActivity().getContentResolver();
+        int color = Settings.System.getInt(resolver,
+                Settings.System.NOTIFICATION_LIGHT_PULSE_DEFAULT_COLOR, mDefaultColor);
+        int timeOn = Settings.System.getInt(resolver,
+                Settings.System.NOTIFICATION_LIGHT_PULSE_DEFAULT_LED_ON, mDefaultLedOn);
+        int timeOff = Settings.System.getInt(resolver,
+                Settings.System.NOTIFICATION_LIGHT_PULSE_DEFAULT_LED_OFF, mDefaultLedOff);
+
+        mDefaultPref.setAllValues(color, timeOn, timeOff);
+
+        // Get Missed call and Voicemail values
+        if (mCallPref != null) {
+            int callColor = Settings.System.getInt(resolver,
+                    Settings.System.NOTIFICATION_LIGHT_PULSE_CALL_COLOR, mDefaultColor);
+            int callTimeOn = Settings.System.getInt(resolver,
+                    Settings.System.NOTIFICATION_LIGHT_PULSE_CALL_LED_ON, mDefaultLedOn);
+            int callTimeOff = Settings.System.getInt(resolver,
+                    Settings.System.NOTIFICATION_LIGHT_PULSE_CALL_LED_OFF, mDefaultLedOff);
+
+            mCallPref.setAllValues(callColor, callTimeOn, callTimeOff);
+        }
+
+        if (mVoicemailPref != null) {
+            int vmailColor = Settings.System.getInt(resolver,
+                    Settings.System.NOTIFICATION_LIGHT_PULSE_VMAIL_COLOR, mDefaultColor);
+            int vmailTimeOn = Settings.System.getInt(resolver,
+                    Settings.System.NOTIFICATION_LIGHT_PULSE_VMAIL_LED_ON, mDefaultLedOn);
+            int vmailTimeOff = Settings.System.getInt(resolver,
+                    Settings.System.NOTIFICATION_LIGHT_PULSE_VMAIL_LED_OFF, mDefaultLedOff);
+
+            mVoicemailPref.setAllValues(vmailColor, vmailTimeOn, vmailTimeOff);
+        }
+
+        if (mLedCanPulse || mMultiColorLed) {
+            mApplicationPrefList = findPreference(APPLICATION_SECTION);
+            mApplicationPrefList.setOrderingAsAdded(false);
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        setChildrenStarted(getPreferenceScreen(), true);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        setChildrenStarted(getPreferenceScreen(), false);
+    }
+
+    private void setChildrenStarted(PreferenceGroup group, boolean started) {
+        final int count = group.getPreferenceCount();
+        for (int i = 0; i < count; i++) {
+            Preference pref = group.getPreference(i);
+            if (pref instanceof ApplicationLightPreference) {
+                ApplicationLightPreference ap = (ApplicationLightPreference) pref;
+                if (started) {
+                    ap.onStart();
+                } else {
+                    ap.onStop();
+                }
+            } else if (pref instanceof PreferenceGroup) {
+                setChildrenStarted((PreferenceGroup) pref, started);
+            }
+        }
+    }
+
+    private void refreshCustomApplicationPrefs() {
+        Context context = getActivity();
+
+        if (!parsePackageList()) {
+            maybeDisplayApplicationHint(context);
+            return;
+        }
+
+        // Add the Application Preferences
+        if (mApplicationPrefList != null) {
+            for (int i = 0; i < mApplicationPrefList.getPreferenceCount();) {
+                Preference pref = mApplicationPrefList.getPreference(i);
+                if (ADD_APPS.equals(pref.getKey())) {
+                    i++;
+                    continue;
+                }
+
+                mApplicationPrefList.removePreference(pref);
+            }
+
+            for (Package pkg : mPackages.values()) {
+                try {
+                    PackageInfo info = mPackageManager.getPackageInfo(pkg.name,
+                            PackageManager.GET_META_DATA);
+                    ApplicationLightPreference pref =
+                            new ApplicationLightPreference(context, null,
+                                    pkg.color, pkg.timeon, pkg.timeoff);
+
+                    pref.setKey(pkg.name);
+                    pref.setTitle(info.applicationInfo.loadLabel(mPackageManager));
+                    pref.setIcon(info.applicationInfo.loadIcon(mPackageManager));
+                    pref.setPersistent(false);
+                    pref.setOnPreferenceChangeListener(this);
+                    pref.setOnLongClickListener(this);
+                    mApplicationPrefList.addPreference(pref);
+                } catch (NameNotFoundException e) {
+                    // Do nothing
+                }
+            }
+
+            maybeDisplayApplicationHint(context);
+            mPackageAdapter.setExcludedPackages(new HashSet(mPackages.keySet()));
+        }
+    }
+
+    private void maybeDisplayApplicationHint(Context context) {
+        /* Display a pref explaining how to add apps */
+        if (mApplicationPrefList != null && mApplicationPrefList.getPreferenceCount() == 1) {
+            String summary = getResources().getString(
+                    R.string.notification_light_add_apps_empty_summary);
+            String useCustom = getResources().getString(
+                    R.string.notification_light_use_custom);
+            Preference pref = new Preference(context);
+            pref.setSummary(String.format(summary, useCustom));
+            pref.setEnabled(false);
+            mApplicationPrefList.addPreference(pref);
+        }
+    }
+
+    private int getInitialColorForPackage(String packageName) {
+        boolean autoColor = Settings.System.getInt(getActivity().getContentResolver(),
+                Settings.System.NOTIFICATION_LIGHT_COLOR_AUTO, mMultiColorLed ? 1 : 0) == 1;
+        int color = mDefaultColor;
+        if (autoColor) {
+            try {
+                Drawable icon = mPackageManager.getApplicationIcon(packageName);
+                color = ColorUtils.generateAlertColorFromDrawable(icon);
+            } catch (NameNotFoundException e) {
+                // shouldn't happen, but just return default
+            }
+        }
+        return color;
+    }
+
+    private void addCustomApplicationPref(String packageName) {
+        Package pkg = mPackages.get(packageName);
+        if (pkg == null) {
+            int color = getInitialColorForPackage(packageName);
+            pkg = new Package(packageName, color, mDefaultLedOn, mDefaultLedOff);
+            mPackages.put(packageName, pkg);
+            savePackageList(false);
+            refreshCustomApplicationPrefs();
+        }
+    }
+
+    private void removeCustomApplicationPref(String packageName) {
+        if (mPackages.remove(packageName) != null) {
+            savePackageList(false);
+            refreshCustomApplicationPrefs();
+        }
+    }
+
+    private boolean parsePackageList() {
+        final String baseString = Settings.System.getString(
+                getActivity().getContentResolver(),
+                Settings.System.NOTIFICATION_LIGHT_PULSE_CUSTOM_VALUES);
+
+        if (TextUtils.equals(mPackageList, baseString)) {
+            return false;
+        }
+
+        mPackageList = baseString;
+        mPackages.clear();
+
+        if (baseString != null) {
+            final String[] array = TextUtils.split(baseString, "\\|");
+            for (String item : array) {
+                if (TextUtils.isEmpty(item)) {
+                    continue;
+                }
+                Package pkg = Package.fromString(item);
+                if (pkg != null) {
+                    mPackages.put(pkg.name, pkg);
+                }
+            }
+        }
+
+        mPackageAdapter.setExcludedPackages(new HashSet<String>(mPackages.keySet()));
+
+        return true;
+    }
+
+    private void savePackageList(boolean preferencesUpdated) {
+        List<String> settings = new ArrayList();
+        for (Package app : mPackages.values()) {
+            settings.add(app.toString());
+        }
+        final String value = TextUtils.join("|", settings);
+        if (preferencesUpdated) {
+            mPackageList = value;
+        }
+        Settings.System.putString(getActivity().getContentResolver(),
+            Settings.System.NOTIFICATION_LIGHT_PULSE_CUSTOM_VALUES, value);
+    }
+
+    /**
+     * Updates the default or package specific notification settings.
+     *
+     * @param packageName Package name of application specific settings to update
+     */
+    protected void updateValues(String packageName, Integer color, Integer timeon,
+                                Integer timeoff) {
+        ContentResolver resolver = getActivity().getContentResolver();
+
+        if (packageName.equals(DEFAULT_PREF)) {
+            Settings.System.putInt(resolver,
+                    Settings.System.NOTIFICATION_LIGHT_PULSE_DEFAULT_COLOR, color);
+            Settings.System.putInt(resolver,
+                    Settings.System.NOTIFICATION_LIGHT_PULSE_DEFAULT_LED_ON, timeon);
+            Settings.System.putInt(resolver,
+                    Settings.System.NOTIFICATION_LIGHT_PULSE_DEFAULT_LED_OFF, timeoff);
+            refreshDefault();
+            return;
+        } else if (packageName.equals(MISSED_CALL_PREF)) {
+            Settings.System.putInt(resolver,
+                    Settings.System.NOTIFICATION_LIGHT_PULSE_CALL_COLOR, color);
+            Settings.System.putInt(resolver,
+                    Settings.System.NOTIFICATION_LIGHT_PULSE_CALL_LED_ON, timeon);
+            Settings.System.putInt(resolver,
+                    Settings.System.NOTIFICATION_LIGHT_PULSE_CALL_LED_OFF, timeoff);
+            refreshDefault();
+            return;
+        } else if (packageName.equals(VOICEMAIL_PREF)) {
+            Settings.System.putInt(resolver,
+                    Settings.System.NOTIFICATION_LIGHT_PULSE_VMAIL_COLOR, color);
+            Settings.System.putInt(resolver,
+                    Settings.System.NOTIFICATION_LIGHT_PULSE_VMAIL_LED_ON, timeon);
+            Settings.System.putInt(resolver,
+                    Settings.System.NOTIFICATION_LIGHT_PULSE_VMAIL_LED_OFF, timeoff);
+            refreshDefault();
+            return;
+        }
+
+        // Find the custom package and sets its new values
+        Package app = mPackages.get(packageName);
+        if (app != null) {
+            app.color = color;
+            app.timeon = timeon;
+            app.timeoff = timeoff;
+            savePackageList(true);
+        }
+    }
+
+    protected void resetColors() {
+        ContentResolver resolver = getActivity().getContentResolver();
+
+        // Reset to the framework default colors
+        Settings.System.putInt(resolver, Settings.System.NOTIFICATION_LIGHT_PULSE_DEFAULT_COLOR, mDefaultColor);
+        Settings.System.putInt(resolver, Settings.System.NOTIFICATION_LIGHT_PULSE_CALL_COLOR, mDefaultColor);
+        Settings.System.putInt(resolver, Settings.System.NOTIFICATION_LIGHT_PULSE_VMAIL_COLOR, mDefaultColor);
+
+        refreshDefault();
+    }
+
+    public boolean onItemLongClick(final String key) {
+        if (mApplicationPrefList.findPreference(key) == null) {
+            return false;
+        }
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
+                .setTitle(R.string.dialog_delete_title)
+                .setMessage(R.string.dialog_delete_message)
+                .setIconAttribute(android.R.attr.alertDialogIcon)
+                .setPositiveButton(android.R.string.ok, (dialog, which) ->
+                        removeCustomApplicationPref(key)
+                )
+                .setNegativeButton(android.R.string.cancel, null);
+
+        builder.show();
+        return true;
+    }
+
+    public boolean onPreferenceChange(Preference preference, Object objValue) {
+        if (preference == mEnabledPref || preference == mCustomEnabledPref ||
+                preference == mScreenOnLightsPref ||
+                preference == mAutoGenerateColors) {
+            getActivity().invalidateOptionsMenu();
+        } else {
+            ApplicationLightPreference lightPref = (ApplicationLightPreference) preference;
+            updateValues(lightPref.getKey(), lightPref.getColor(),
+                    lightPref.getOnValue(), lightPref.getOffValue());
+        }
+
+        return true;
+    }
+
+    /**
+     * Utility classes and supporting methods
+     */
+    @Override
+    public Dialog onCreateDialog(int id) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        final Dialog dialog;
+        switch (id) {
+            case DIALOG_APPS:
+                Resources res = getResources();
+                int paddingTop = res.getDimensionPixelOffset(R.dimen.package_list_padding_top);
+
+                final ListView list = new ListView(getActivity());
+                list.setAdapter(mPackageAdapter);
+                list.setDivider(null);
+                list.setPadding(0, paddingTop, 0, 0);
+
+                builder.setTitle(R.string.choose_app);
+                builder.setView(list);
+                dialog = builder.create();
+
+                list.setOnItemClickListener((parent, view, position, id1) -> {
+                    // Add empty application definition, the user will be able to edit it later
+                    PackageItem info = (PackageItem) parent.getItemAtPosition(position);
+                    addCustomApplicationPref(info.packageName);
+                    dialog.cancel();
+                });
+                break;
+            default:
+                dialog = null;
+        }
+        return dialog;
+    }
+
+    @Override
+    public int getDialogMetricsCategory(int dialogId) {
+        if (dialogId == DIALOG_APPS) {
+            return MetricsEvent.EVO_SETTINGS;
+        }
+        return 0;
+    }
+
+    /**
+     * Application class
+     */
+    private static class Package {
+        public String name;
+        public Integer color;
+        public Integer timeon;
+        public Integer timeoff;
+
+        /**
+         * Stores all the application values in one call
+         */
+        public Package(String name, Integer color, Integer timeon, Integer timeoff) {
+            this.name = name;
+            this.color = color;
+            this.timeon = timeon;
+            this.timeoff = timeoff;
+        }
+
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            builder.append(name);
+            builder.append("=");
+            builder.append(color);
+            builder.append(";");
+            builder.append(timeon);
+            builder.append(";");
+            builder.append(timeoff);
+            return builder.toString();
+        }
+
+        public static Package fromString(String value) {
+            if (TextUtils.isEmpty(value)) {
+                return null;
+            }
+            String[] app = value.split("=", -1);
+            if (app.length != 2)
+                return null;
+
+            String[] values = app[1].split(";", -1);
+            if (values.length != 3)
+                return null;
+
+            try {
+                return new Package(app[0], Integer.parseInt(values[0]), Integer
+                        .parseInt(values[1]), Integer.parseInt(values[2]));
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsEvent.EVO_SETTINGS;
+    }
+
+    @Override
+    public void onDisplayPreferenceDialog(Preference preference) {
+        if (preference.getKey() == null) {
+            // Auto-key preferences that don't have a key, so the dialog can find them.
+            preference.setKey(UUID.randomUUID().toString());
+        }
+        DialogFragment f = null;
+        if (preference instanceof CustomDialogPreference) {
+            f = CustomDialogPreference.CustomPreferenceDialogFragment
+                    .newInstance(preference.getKey());
+        } else {
+            super.onDisplayPreferenceDialog(preference);
+            return;
+        }
+        f.setTargetFragment(this, 0);
+        f.show(getFragmentManager(), "dialog_preference");
+        onDialogShowing();
+    }
+}

--- a/src/com/android/settings/flashlight/FlashlightHandleActivity.java
+++ b/src/com/android/settings/flashlight/FlashlightHandleActivity.java
@@ -87,10 +87,7 @@ public class FlashlightHandleActivity extends Activity implements Indexable {
                 @Override
                 public List<String> getNonIndexableKeys(Context context) {
                     List<String> keys = super.getNonIndexableKeys(context);
-                    if (!FlashlightSlice.isFlashlightAvailable(context)) {
-                        Log.i(TAG, "Flashlight is unavailable");
-                        keys.add(DATA_KEY);
-                    }
+                    keys.add(DATA_KEY);
                     return keys;
                 }
             };

--- a/src/com/android/settings/fuelgauge/AllowBackgroundPreferenceController.java
+++ b/src/com/android/settings/fuelgauge/AllowBackgroundPreferenceController.java
@@ -49,9 +49,16 @@ public class AllowBackgroundPreferenceController extends AbstractPreferenceContr
         }
     }
 
+    private void setEnabled(Preference preference, boolean enabled) {
+        preference.setEnabled(enabled);
+        if (preference instanceof PrimarySwitchPreference) {
+            ((PrimarySwitchPreference) preference).setSwitchEnabled(enabled);
+        }
+    }
+
     @Override
     public void updateState(Preference preference) {
-        preference.setEnabled(mBatteryOptimizeUtils.isOptimizeModeMutable());
+        setEnabled(preference, mBatteryOptimizeUtils.isOptimizeModeMutable());
 
         final boolean isAllowBackground =
                 mBatteryOptimizeUtils.getAppOptimizationMode()

--- a/src/com/android/settings/fuelgauge/BatteryChargeSoundSettings.java
+++ b/src/com/android/settings/fuelgauge/BatteryChargeSoundSettings.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2009 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.fuelgauge;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.media.Ringtone;
+import android.media.RingtoneManager;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.UserHandle;
+import android.provider.Settings;
+import android.util.Log;
+
+import androidx.preference.Preference;
+import androidx.preference.Preference.OnPreferenceChangeListener;
+import androidx.preference.SwitchPreference;
+
+import com.android.internal.logging.nano.MetricsProto;
+import com.android.settings.R;
+import com.android.settings.SettingsPreferenceFragment;
+
+import com.evolution.settings.preference.CustomSeekBarPreference;
+import com.evolution.settings.preference.SystemSettingMainSwitchPreference;
+
+public class BatteryChargeSoundSettings extends SettingsPreferenceFragment implements
+        Preference.OnPreferenceChangeListener {
+
+    private static final int REQUEST_CODE_RINGTONE = 1;
+    private static final String KEY_BATTERY_LEVEL_CHARGE_ALARM_ENABLED = "battery_level_charge_alarm_enabled";
+    private static final String KEY_BATTERY_LEVEL_CHARGE_RINGTONE = "battery_level_charge_ringtone";
+    private static final String KEY_BATTERY_LEVEL_CHARGE_SEEK_BAR = "battery_level_charge_seek_bar";
+    private static final String KEY_SOUND_SILENT = "silent";
+
+    private CustomSeekBarPreference mBatteryLevelChargeSeekbar;
+    private Preference mBatteryLevelChargeRingtone;
+    private SystemSettingMainSwitchPreference mBatteryLevelChargeAlarmEnabled;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.notification_charge_level_settings);
+
+        mBatteryLevelChargeAlarmEnabled = (SystemSettingMainSwitchPreference) findPreference(KEY_BATTERY_LEVEL_CHARGE_ALARM_ENABLED);
+        mBatteryLevelChargeAlarmEnabled.setChecked(Settings.System.getIntForUser(getContentResolver(),
+                Settings.System.BATTERY_LEVEL_CHARGE_ALARM_ENABLED, 0, UserHandle.USER_CURRENT) == 1);
+        mBatteryLevelChargeAlarmEnabled.setOnPreferenceChangeListener(this);
+
+        mBatteryLevelChargeSeekbar = (CustomSeekBarPreference) findPreference(KEY_BATTERY_LEVEL_CHARGE_SEEK_BAR);
+        int batterylevelchargeseekbar = Settings.System.getIntForUser(getContentResolver(),
+                Settings.System.SEEK_BAR_BATTERY_CHARGE_LEVEL_SOUND, 100, UserHandle.USER_CURRENT);
+        mBatteryLevelChargeSeekbar.setValue(batterylevelchargeseekbar);
+        mBatteryLevelChargeSeekbar.setOnPreferenceChangeListener(this);
+
+        mBatteryLevelChargeRingtone = (Preference) findPreference(KEY_BATTERY_LEVEL_CHARGE_RINGTONE);
+        String curTone = Settings.Global.getString(getContentResolver(),
+                Settings.Global.BATTERY_LEVEL_CHARGE_SOUND_ALARM);
+        if (curTone == null) {
+            updateChargeLevelRingtone(Settings.System.DEFAULT_NOTIFICATION_URI.toString(), true);
+        } else {
+            updateChargeLevelRingtone(curTone, false);
+        }
+    }
+
+    private void updateChargeLevelRingtone(String toneUriString, boolean persist) {
+        final String toneName;
+
+        if (toneUriString != null && !toneUriString.equals(KEY_SOUND_SILENT)) {
+            final Ringtone ringtone = RingtoneManager.getRingtone(getActivity(),
+                    Uri.parse(toneUriString));
+            if (ringtone != null) {
+                toneName = ringtone.getTitle(getActivity());
+            } else {
+                toneName = "";
+                toneUriString = Settings.System.DEFAULT_NOTIFICATION_URI.toString();
+                persist = true;
+            }
+        } else {
+            toneName = getString(R.string.notification_battery_charge_level_silent);
+            toneUriString = KEY_SOUND_SILENT;
+        }
+
+        mBatteryLevelChargeRingtone.setSummary(toneName);
+        if (persist) {
+            Settings.Global.putString(getContentResolver(),
+                    Settings.Global.BATTERY_LEVEL_CHARGE_SOUND_ALARM, toneUriString);
+        }
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        if (preference.equals(mBatteryLevelChargeAlarmEnabled)) {
+            boolean enabled = ((Boolean) newValue).booleanValue();
+            Settings.System.putIntForUser(getContentResolver(),
+                    Settings.System.BATTERY_LEVEL_CHARGE_ALARM_ENABLED, enabled ? 1 : 0, UserHandle.USER_CURRENT);
+            return true;
+        } else if (preference.equals(mBatteryLevelChargeSeekbar)) {
+            int val = (Integer) newValue;
+            Settings.System.putIntForUser(getContentResolver(),
+                    Settings.System.SEEK_BAR_BATTERY_CHARGE_LEVEL_SOUND, val, UserHandle.USER_CURRENT);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean onPreferenceTreeClick(Preference preference) {
+        if (preference.equals(mBatteryLevelChargeRingtone)) {
+            batteryChargeSoundSoundPicker(REQUEST_CODE_RINGTONE,
+                    Settings.Global.getString(getContentResolver(),
+                    Settings.Global.BATTERY_LEVEL_CHARGE_SOUND_ALARM));
+        }
+        return super.onPreferenceTreeClick(preference);
+    }
+
+    private void batteryChargeSoundSoundPicker(int requestCode, String toneUriString) {
+        final Intent intent = new Intent(RingtoneManager.ACTION_RINGTONE_PICKER);
+
+        intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TITLE,
+                getString(R.string.notification_battery_charge_level_ringtone));
+        intent.putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE,
+                RingtoneManager.TYPE_NOTIFICATION);
+        intent.putExtra(RingtoneManager.EXTRA_RINGTONE_DEFAULT_URI,
+                Settings.System.DEFAULT_NOTIFICATION_URI);
+        if (toneUriString != null && !toneUriString.equals(KEY_SOUND_SILENT)) {
+            Uri uri = Uri.parse(toneUriString);
+            if (uri != null) {
+                intent.putExtra(RingtoneManager.EXTRA_RINGTONE_EXISTING_URI, uri);
+            }
+        }
+        startActivityForResult(intent, requestCode);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == REQUEST_CODE_RINGTONE
+                && resultCode == Activity.RESULT_OK) {
+            Uri uri = data.getParcelableExtra(RingtoneManager.EXTRA_RINGTONE_PICKED_URI);
+            updateChargeLevelRingtone(uri != null ? uri.toString() : null, true);
+        }
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsProto.MetricsEvent.EVO_SETTINGS;
+    }
+
+}

--- a/src/com/android/settings/fuelgauge/BatteryChargeSoundSettings.java
+++ b/src/com/android/settings/fuelgauge/BatteryChargeSoundSettings.java
@@ -29,7 +29,8 @@ import android.util.Log;
 
 import androidx.preference.Preference;
 import androidx.preference.Preference.OnPreferenceChangeListener;
-import androidx.preference.SwitchPreference;
+import androidx.preference.SwitchPreferenceCompat;
+import androidx.preference.TwoStatePreference;
 
 import com.android.internal.logging.nano.MetricsProto;
 import com.android.settings.R;

--- a/src/com/android/settings/fuelgauge/BatteryHeaderPreferenceController.java
+++ b/src/com/android/settings/fuelgauge/BatteryHeaderPreferenceController.java
@@ -129,9 +129,17 @@ public class BatteryHeaderPreferenceController extends BasePreferenceController
         final int batteryLevel = Utils.getBatteryLevel(batteryBroadcast);
         final boolean discharging =
                 batteryBroadcast.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1) == 0;
+        final int chargeCounterUah =
+                batteryBroadcast.getIntExtra(BatteryManager.EXTRA_CHARGE_COUNTER, -1);
 
         mBatteryUsageProgressBarPref.setUsageSummary(formatBatteryPercentageText(batteryLevel));
         mBatteryUsageProgressBarPref.setPercent(batteryLevel, BATTERY_MAX_LEVEL);
+
+        if (chargeCounterUah != -1) {
+            int chargeCounter = chargeCounterUah / 1_000;
+            mBatteryUsageProgressBarPref.setTotalSummary(
+                    formatBatteryChargeCounterText(chargeCounter));
+        }
     }
 
     /** Update summary when battery tips changed. */
@@ -147,5 +155,9 @@ public class BatteryHeaderPreferenceController extends BasePreferenceController
         return TextUtils.expandTemplate(
                 mContext.getText(R.string.battery_header_title_alternate),
                 NumberFormat.getIntegerInstance().format(batteryLevel));
+    }
+
+    private CharSequence formatBatteryChargeCounterText(int chargeCounter) {
+        return mContext.getString(R.string.battery_charge_counter_summary, chargeCounter);
     }
 }

--- a/src/com/android/settings/fuelgauge/BatterySettingsFeatureProviderImpl.java
+++ b/src/com/android/settings/fuelgauge/BatterySettingsFeatureProviderImpl.java
@@ -18,6 +18,7 @@ package com.android.settings.fuelgauge;
 
 import android.content.Context;
 
+import com.android.settings.R;
 import com.android.settings.fuelgauge.batterytip.tips.BatteryTip;
 
 import java.util.List;
@@ -37,7 +38,7 @@ public class BatterySettingsFeatureProviderImpl implements BatterySettingsFeatur
 
     @Override
     public boolean isBatteryInfoEnabled(Context context) {
-        return true;
+        return context.getResources().getBoolean(R.bool.config_show_battery_info);
     }
 
     @Override

--- a/src/com/android/settings/fuelgauge/BatterySettingsFeatureProviderImpl.java
+++ b/src/com/android/settings/fuelgauge/BatterySettingsFeatureProviderImpl.java
@@ -27,17 +27,17 @@ public class BatterySettingsFeatureProviderImpl implements BatterySettingsFeatur
 
     @Override
     public boolean isManufactureDateAvailable(Context context, long manufactureDateMs) {
-        return false;
+        return manufactureDateMs > 1_500_000_000_000L; // July 2017
     }
 
     @Override
     public boolean isFirstUseDateAvailable(Context context, long firstUseDateMs) {
-        return false;
+        return firstUseDateMs > 1_500_000_000_000L; // July 2017
     }
 
     @Override
     public boolean isBatteryInfoEnabled(Context context) {
-        return false;
+        return true;
     }
 
     @Override

--- a/src/com/android/settings/fuelgauge/BatterySettingsFeatureProviderImpl.java
+++ b/src/com/android/settings/fuelgauge/BatterySettingsFeatureProviderImpl.java
@@ -27,12 +27,12 @@ public class BatterySettingsFeatureProviderImpl implements BatterySettingsFeatur
 
     @Override
     public boolean isManufactureDateAvailable(Context context, long manufactureDateMs) {
-        return manufactureDateMs > 1_500_000_000_000L; // July 2017
+        return manufactureDateMs > 1_609_459_200_000L; // 2021-01-01
     }
 
     @Override
     public boolean isFirstUseDateAvailable(Context context, long firstUseDateMs) {
-        return firstUseDateMs > 1_500_000_000_000L; // July 2017
+        return firstUseDateMs > 1_609_459_200_000L; // 2021-01-01
     }
 
     @Override

--- a/src/com/android/settings/fuelgauge/batteryusage/DataProcessor.java
+++ b/src/com/android/settings/fuelgauge/batteryusage/DataProcessor.java
@@ -1453,18 +1453,6 @@ public final class DataProcessor {
                                 currentEntry.mCachedUsageConsumePower,
                                 nextEntry.mCachedUsageConsumePower);
             }
-            if (isSystemConsumer(selectedBatteryEntry.mConsumerType)
-                    && selectedBatteryEntry.mDrainType == BatteryConsumer.POWER_COMPONENT_SCREEN) {
-                // Replace Screen system component time with screen on time.
-                foregroundUsageTimeInMs = slotScreenOnTime;
-            }
-            // Excludes entry since we don't have enough data to calculate.
-            if (foregroundUsageTimeInMs == 0
-                    && foregroundServiceUsageTimeInMs == 0
-                    && backgroundUsageTimeInMs == 0
-                    && consumePower == 0) {
-                continue;
-            }
             // Forces refine the cumulative value since it may introduce deviation error since we
             // will apply the interpolation arithmetic.
             final float totalUsageTimeInMs =

--- a/src/com/android/settings/fuelgauge/batteryusage/PowerUsageSummary.java
+++ b/src/com/android/settings/fuelgauge/batteryusage/PowerUsageSummary.java
@@ -50,7 +50,6 @@ import com.android.settings.overlay.FeatureFactory;
 import com.android.settings.search.BaseSearchIndexProvider;
 import com.android.settingslib.search.SearchIndexable;
 
-import java.lang.Integer;
 import java.time.format.DateTimeFormatter;
 import java.time.LocalTime;
 import java.util.ArrayList;

--- a/src/com/android/settings/fuelgauge/batteryusage/ScreenOnTimeController.java
+++ b/src/com/android/settings/fuelgauge/batteryusage/ScreenOnTimeController.java
@@ -64,7 +64,7 @@ public class ScreenOnTimeController extends BasePreferenceController {
     }
 
     void handleSceenOnTimeUpdated(Long screenOnTime, String slotTimestamp) {
-        if (screenOnTime == null) {
+        if (screenOnTime == null || screenOnTime <= 0) {
             mRootPreference.setVisible(false);
             mScreenOnTimeTextPreference.setVisible(false);
             return;

--- a/src/com/android/settings/fuelgauge/batteryusage/db/BatteryStateDatabase.java
+++ b/src/com/android/settings/fuelgauge/batteryusage/db/BatteryStateDatabase.java
@@ -31,7 +31,8 @@ import androidx.room.RoomDatabase;
             BatteryState.class,
             BatteryUsageSlotEntity.class
         },
-        version = 1)
+        version = 1,
+        exportSchema = false)
 public abstract class BatteryStateDatabase extends RoomDatabase {
     private static final String TAG = "BatteryStateDatabase";
 

--- a/src/com/android/settings/fuelgauge/sleepmode/SleepMode.java
+++ b/src/com/android/settings/fuelgauge/sleepmode/SleepMode.java
@@ -26,7 +26,8 @@ import android.os.UserHandle;
 import android.provider.Settings;
 import android.text.format.DateFormat;
 import android.view.View;
-import android.widget.Switch;
+import android.widget.CompoundButton;
+import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.TimePicker;
 
 import androidx.preference.DropDownPreference;
@@ -39,13 +40,12 @@ import com.android.settings.R;
 import com.android.settings.SettingsPreferenceFragment;
 import com.evolution.settings.preference.CustomSecureSettingMainSwitchPreference;
 
-import com.android.settingslib.widget.OnMainSwitchChangeListener;
 
 import java.time.format.DateTimeFormatter;
 import java.time.LocalTime;
 
 public class SleepMode extends SettingsPreferenceFragment implements
-        Preference.OnPreferenceClickListener, Preference.OnPreferenceChangeListener, OnMainSwitchChangeListener {
+        Preference.OnPreferenceClickListener, Preference.OnPreferenceChangeListener, OnCheckedChangeListener {
 
     private static final String ENABLE_KEY = "sleep_mode_enabled";
     private static final String MODE_KEY = "sleep_mode_auto_mode";
@@ -141,7 +141,7 @@ public class SleepMode extends SettingsPreferenceFragment implements
     }
 
     @Override
-    public void onSwitchChanged(Switch switchView, boolean isChecked) {
+    public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
         enableSleepMode(isChecked);
         updateStateInternal();
         mHandler.postDelayed(new Runnable() {

--- a/src/com/android/settings/gestures/GestureTweaksSettings.java
+++ b/src/com/android/settings/gestures/GestureTweaksSettings.java
@@ -75,6 +75,7 @@ public class GestureTweaksSettings extends SettingsPreferenceFragment
         mLeftSwipeActions = (ListPreference) findPreference("left_swipe_actions");
         mLeftSwipeActions.setValue(Integer.toString(leftSwipeActions));
         mLeftSwipeActions.setSummary(mLeftSwipeActions.getEntry());
+        mLeftSwipeActions.setEnabled(extendedSwipe);
         mLeftSwipeActions.setOnPreferenceChangeListener(this);
 
         int rightSwipeActions = Settings.System.getIntForUser(resolver,
@@ -83,6 +84,7 @@ public class GestureTweaksSettings extends SettingsPreferenceFragment
         mRightSwipeActions = (ListPreference) findPreference("right_swipe_actions");
         mRightSwipeActions.setValue(Integer.toString(rightSwipeActions));
         mRightSwipeActions.setSummary(mRightSwipeActions.getEntry());
+        mRightSwipeActions.setEnabled(extendedSwipe);
         mRightSwipeActions.setOnPreferenceChangeListener(this);
 
         mLeftSwipeAppSelection = (Preference) findPreference("left_swipe_app_action");
@@ -135,7 +137,7 @@ public class GestureTweaksSettings extends SettingsPreferenceFragment
             int index = mLeftSwipeActions.findIndexOfValue((String) newValue);
             mLeftSwipeActions.setSummary(
                     mLeftSwipeActions.getEntries()[index]);
-            mLeftSwipeAppSelection.setVisible(leftSwipeActions == 4);
+            mLeftSwipeAppSelection.setVisible(mExtendedSwipe.isChecked() && leftSwipeActions == 4);
             actionPreferenceReload();
             customAppCheck();
             return true;
@@ -147,7 +149,7 @@ public class GestureTweaksSettings extends SettingsPreferenceFragment
             int index = mRightSwipeActions.findIndexOfValue((String) newValue);
             mRightSwipeActions.setSummary(
                     mRightSwipeActions.getEntries()[index]);
-            mRightSwipeAppSelection.setVisible(rightSwipeActions == 4);
+            mRightSwipeAppSelection.setVisible(mExtendedSwipe.isChecked() && rightSwipeActions == 4);
             actionPreferenceReload();
             customAppCheck();
             return true;
@@ -176,6 +178,8 @@ public class GestureTweaksSettings extends SettingsPreferenceFragment
         } else if (preference == mExtendedSwipe) {
             boolean enabled = ((Boolean) newValue).booleanValue();
             mExtendedSwipe.setChecked(enabled);
+            mLeftSwipeActions.setEnabled(enabled);
+            mRightSwipeActions.setEnabled(enabled);
             mLeftVerticalSwipeActions.setEnabled(enabled);
             mRightVerticalSwipeActions.setEnabled(enabled);
             mLeftVerticalSwipeAppSelection.setVisible(enabled && mLeftVerticalSwipeActions.getValue().equals("4"));

--- a/src/com/android/settings/gestures/GestureTweaksSettings.java
+++ b/src/com/android/settings/gestures/GestureTweaksSettings.java
@@ -36,7 +36,6 @@ import com.android.settings.search.BaseSearchIndexProvider;
 import com.android.settings.SettingsPreferenceFragment;
 import com.android.settingslib.search.SearchIndexable;
 
-import com.evolution.settings.preference.SystemSettingListPreference;
 import com.evolution.settings.preference.SystemSettingSwitchPreference;
 
 import java.util.ArrayList;
@@ -54,7 +53,6 @@ public class GestureTweaksSettings extends SettingsPreferenceFragment
     private ListPreference mRightVerticalSwipeActions;
     private Preference mLeftVerticalSwipeAppSelection;
     private Preference mRightVerticalSwipeAppSelection;
-    private SystemSettingListPreference mTimeout;
     private SystemSettingSwitchPreference mExtendedSwipe;
 
     @Override
@@ -64,14 +62,12 @@ public class GestureTweaksSettings extends SettingsPreferenceFragment
 
         final ContentResolver resolver = getActivity().getContentResolver();
 
-        mTimeout = (SystemSettingListPreference) findPreference("long_back_swipe_timeout");
         mExtendedSwipe = (SystemSettingSwitchPreference) findPreference("back_swipe_extended");
         boolean extendedSwipe = Settings.System.getIntForUser(resolver,
             Settings.System.BACK_SWIPE_EXTENDED, 0,
             UserHandle.USER_CURRENT) != 0;
         mExtendedSwipe.setChecked(extendedSwipe);
         mExtendedSwipe.setOnPreferenceChangeListener(this);
-        mTimeout.setEnabled(!mExtendedSwipe.isChecked());
 
         int leftSwipeActions = Settings.System.getIntForUser(resolver,
                 Settings.System.LEFT_LONG_BACK_SWIPE_ACTION, 0,
@@ -180,7 +176,6 @@ public class GestureTweaksSettings extends SettingsPreferenceFragment
         } else if (preference == mExtendedSwipe) {
             boolean enabled = ((Boolean) newValue).booleanValue();
             mExtendedSwipe.setChecked(enabled);
-            mTimeout.setEnabled(!enabled);
             mLeftVerticalSwipeActions.setEnabled(enabled);
             mRightVerticalSwipeActions.setEnabled(enabled);
             mLeftVerticalSwipeAppSelection.setVisible(enabled && mLeftVerticalSwipeActions.getValue().equals("4"));

--- a/src/com/android/settings/gestures/GestureTweaksSettings.java
+++ b/src/com/android/settings/gestures/GestureTweaksSettings.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (C) 2020 abcduwhatever
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.gestures;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.os.Bundle;
+import android.os.UserHandle;
+import android.provider.SearchIndexableResource;
+import android.provider.Settings;
+import androidx.preference.PreferenceCategory;
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.Preference.OnPreferenceChangeListener;
+import androidx.preference.SwitchPreference;
+
+import com.android.internal.logging.nano.MetricsProto;
+
+import com.android.settings.R;
+import com.android.settings.search.BaseSearchIndexProvider;
+import com.android.settings.SettingsPreferenceFragment;
+import com.android.settingslib.search.SearchIndexable;
+
+import com.evolution.settings.preference.SystemSettingListPreference;
+import com.evolution.settings.preference.SystemSettingSwitchPreference;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SearchIndexable
+public class GestureTweaksSettings extends SettingsPreferenceFragment
+        implements Preference.OnPreferenceChangeListener {
+
+    private ListPreference mLeftSwipeActions;
+    private ListPreference mRightSwipeActions;
+    private Preference mLeftSwipeAppSelection;
+    private Preference mRightSwipeAppSelection;
+    private ListPreference mLeftVerticalSwipeActions;
+    private ListPreference mRightVerticalSwipeActions;
+    private Preference mLeftVerticalSwipeAppSelection;
+    private Preference mRightVerticalSwipeAppSelection;
+    private SystemSettingListPreference mTimeout;
+    private SystemSettingSwitchPreference mExtendedSwipe;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.gesture_nav_tweaks);
+
+        final ContentResolver resolver = getActivity().getContentResolver();
+
+        mTimeout = (SystemSettingListPreference) findPreference("long_back_swipe_timeout");
+        mExtendedSwipe = (SystemSettingSwitchPreference) findPreference("back_swipe_extended");
+        boolean extendedSwipe = Settings.System.getIntForUser(resolver,
+            Settings.System.BACK_SWIPE_EXTENDED, 0,
+            UserHandle.USER_CURRENT) != 0;
+        mExtendedSwipe.setChecked(extendedSwipe);
+        mExtendedSwipe.setOnPreferenceChangeListener(this);
+        mTimeout.setEnabled(!mExtendedSwipe.isChecked());
+
+        int leftSwipeActions = Settings.System.getIntForUser(resolver,
+                Settings.System.LEFT_LONG_BACK_SWIPE_ACTION, 0,
+                UserHandle.USER_CURRENT);
+        mLeftSwipeActions = (ListPreference) findPreference("left_swipe_actions");
+        mLeftSwipeActions.setValue(Integer.toString(leftSwipeActions));
+        mLeftSwipeActions.setSummary(mLeftSwipeActions.getEntry());
+        mLeftSwipeActions.setOnPreferenceChangeListener(this);
+
+        int rightSwipeActions = Settings.System.getIntForUser(resolver,
+                Settings.System.RIGHT_LONG_BACK_SWIPE_ACTION, 0,
+                UserHandle.USER_CURRENT);
+        mRightSwipeActions = (ListPreference) findPreference("right_swipe_actions");
+        mRightSwipeActions.setValue(Integer.toString(rightSwipeActions));
+        mRightSwipeActions.setSummary(mRightSwipeActions.getEntry());
+        mRightSwipeActions.setOnPreferenceChangeListener(this);
+
+        mLeftSwipeAppSelection = (Preference) findPreference("left_swipe_app_action");
+        boolean isAppSelection = Settings.System.getIntForUser(resolver,
+                Settings.System.LEFT_LONG_BACK_SWIPE_ACTION, 0, UserHandle.USER_CURRENT) == 4/*action_app_action*/;
+        mLeftSwipeAppSelection.setVisible(isAppSelection);
+
+        mRightSwipeAppSelection = (Preference) findPreference("right_swipe_app_action");
+        isAppSelection = Settings.System.getIntForUser(resolver,
+                Settings.System.RIGHT_LONG_BACK_SWIPE_ACTION, 0, UserHandle.USER_CURRENT) == 4/*action_app_action*/;
+        mRightSwipeAppSelection.setVisible(isAppSelection);
+
+        int leftVerticalSwipeActions = Settings.System.getIntForUser(resolver,
+                Settings.System.LEFT_VERTICAL_BACK_SWIPE_ACTION, 0,
+                UserHandle.USER_CURRENT);
+        mLeftVerticalSwipeActions = (ListPreference) findPreference("left_vertical_swipe_actions");
+        mLeftVerticalSwipeActions.setValue(Integer.toString(leftVerticalSwipeActions));
+        mLeftVerticalSwipeActions.setSummary(mLeftVerticalSwipeActions.getEntry());
+        mLeftVerticalSwipeActions.setEnabled(extendedSwipe);
+        mLeftVerticalSwipeActions.setOnPreferenceChangeListener(this);
+
+        int rightVerticalSwipeActions = Settings.System.getIntForUser(resolver,
+                Settings.System.RIGHT_VERTICAL_BACK_SWIPE_ACTION, 0,
+                UserHandle.USER_CURRENT);
+        mRightVerticalSwipeActions = (ListPreference) findPreference("right_vertical_swipe_actions");
+        mRightVerticalSwipeActions.setValue(Integer.toString(rightVerticalSwipeActions));
+        mRightVerticalSwipeActions.setSummary(mRightVerticalSwipeActions.getEntry());
+        mRightVerticalSwipeActions.setEnabled(extendedSwipe);
+        mRightVerticalSwipeActions.setOnPreferenceChangeListener(this);
+
+        mLeftVerticalSwipeAppSelection = (Preference) findPreference("left_vertical_swipe_app_action");
+        isAppSelection = Settings.System.getIntForUser(resolver,
+                Settings.System.LEFT_VERTICAL_BACK_SWIPE_ACTION, 0, UserHandle.USER_CURRENT) == 4/*action_app_action*/;
+        mLeftVerticalSwipeAppSelection.setVisible(extendedSwipe && isAppSelection);
+
+        mRightVerticalSwipeAppSelection = (Preference) findPreference("right_vertical_swipe_app_action");
+        isAppSelection = Settings.System.getIntForUser(resolver,
+                Settings.System.RIGHT_VERTICAL_BACK_SWIPE_ACTION, 0, UserHandle.USER_CURRENT) == 4/*action_app_action*/;
+        mRightVerticalSwipeAppSelection.setVisible(extendedSwipe && isAppSelection);
+
+        customAppCheck();
+    }
+
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        if (preference == mLeftSwipeActions) {
+            int leftSwipeActions = Integer.valueOf((String) newValue);
+            Settings.System.putIntForUser(getContentResolver(),
+                    Settings.System.LEFT_LONG_BACK_SWIPE_ACTION, leftSwipeActions,
+                    UserHandle.USER_CURRENT);
+            int index = mLeftSwipeActions.findIndexOfValue((String) newValue);
+            mLeftSwipeActions.setSummary(
+                    mLeftSwipeActions.getEntries()[index]);
+            mLeftSwipeAppSelection.setVisible(leftSwipeActions == 4);
+            actionPreferenceReload();
+            customAppCheck();
+            return true;
+        } else if (preference == mRightSwipeActions) {
+            int rightSwipeActions = Integer.valueOf((String) newValue);
+            Settings.System.putIntForUser(getContentResolver(),
+                    Settings.System.RIGHT_LONG_BACK_SWIPE_ACTION, rightSwipeActions,
+                    UserHandle.USER_CURRENT);
+            int index = mRightSwipeActions.findIndexOfValue((String) newValue);
+            mRightSwipeActions.setSummary(
+                    mRightSwipeActions.getEntries()[index]);
+            mRightSwipeAppSelection.setVisible(rightSwipeActions == 4);
+            actionPreferenceReload();
+            customAppCheck();
+            return true;
+        } else if (preference == mLeftVerticalSwipeActions) {
+            int leftVerticalSwipeActions = Integer.valueOf((String) newValue);
+            Settings.System.putIntForUser(getContentResolver(),
+                    Settings.System.LEFT_VERTICAL_BACK_SWIPE_ACTION, leftVerticalSwipeActions,
+                    UserHandle.USER_CURRENT);
+            int index = mLeftVerticalSwipeActions.findIndexOfValue((String) newValue);
+            mLeftVerticalSwipeActions.setSummary(
+                    mLeftVerticalSwipeActions.getEntries()[index]);
+            mLeftVerticalSwipeAppSelection.setVisible(mExtendedSwipe.isChecked() && leftVerticalSwipeActions == 4);
+            customAppCheck();
+            return true;
+        } else if (preference == mRightVerticalSwipeActions) {
+            int rightVerticalSwipeActions = Integer.valueOf((String) newValue);
+            Settings.System.putIntForUser(getContentResolver(),
+                    Settings.System.RIGHT_VERTICAL_BACK_SWIPE_ACTION, rightVerticalSwipeActions,
+                    UserHandle.USER_CURRENT);
+            int index = mRightVerticalSwipeActions.findIndexOfValue((String) newValue);
+            mRightVerticalSwipeActions.setSummary(
+                    mRightVerticalSwipeActions.getEntries()[index]);
+            mRightVerticalSwipeAppSelection.setVisible(mExtendedSwipe.isChecked() && rightVerticalSwipeActions == 4);
+            customAppCheck();
+            return true; 
+        } else if (preference == mExtendedSwipe) {
+            boolean enabled = ((Boolean) newValue).booleanValue();
+            mExtendedSwipe.setChecked(enabled);
+            mTimeout.setEnabled(!enabled);
+            mLeftVerticalSwipeActions.setEnabled(enabled);
+            mRightVerticalSwipeActions.setEnabled(enabled);
+            mLeftVerticalSwipeAppSelection.setVisible(enabled && mLeftVerticalSwipeActions.getValue().equals("4"));
+            mRightVerticalSwipeAppSelection.setVisible(enabled && mRightVerticalSwipeActions.getValue().equals("4"));
+            return true; 
+        }
+        return false;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        // Ensure preferences sensible to change get updated
+        actionPreferenceReload();
+        customAppCheck();
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        // Ensure preferences sensible to change gets updated
+        actionPreferenceReload();
+        customAppCheck();
+    }
+
+    /* Helper for reloading both short and long gesture as they might change on
+       package uninstallation */
+    private void actionPreferenceReload() {
+        int leftSwipeActions = Settings.System.getIntForUser(getContentResolver(),
+                Settings.System.LEFT_LONG_BACK_SWIPE_ACTION, 0,
+                UserHandle.USER_CURRENT);
+
+        int rightSwipeActions = Settings.System.getIntForUser(getContentResolver(),
+                Settings.System.RIGHT_LONG_BACK_SWIPE_ACTION, 0,
+                UserHandle.USER_CURRENT);
+
+        // Reload the action preferences
+        mLeftSwipeActions.setValue(Integer.toString(leftSwipeActions));
+        mLeftSwipeActions.setSummary(mLeftSwipeActions.getEntry());
+
+        mRightSwipeActions.setValue(Integer.toString(rightSwipeActions));
+        mRightSwipeActions.setSummary(mRightSwipeActions.getEntry());
+
+        mLeftSwipeAppSelection.setVisible(mLeftSwipeActions.getEntryValues()
+                [leftSwipeActions].equals("4"));
+        mRightSwipeAppSelection.setVisible(mRightSwipeActions.getEntryValues()
+                [rightSwipeActions].equals("4"));
+
+        int leftVerticalSwipeActions = Settings.System.getIntForUser(getContentResolver(),
+                Settings.System.LEFT_VERTICAL_BACK_SWIPE_ACTION, 0,
+                UserHandle.USER_CURRENT);
+
+        int rightVerticalSwipeActions = Settings.System.getIntForUser(getContentResolver(),
+                Settings.System.RIGHT_VERTICAL_BACK_SWIPE_ACTION, 0,
+                UserHandle.USER_CURRENT);
+
+        // Reload the action preferences
+        mLeftVerticalSwipeActions.setValue(Integer.toString(leftVerticalSwipeActions));
+        mLeftVerticalSwipeActions.setSummary(mLeftVerticalSwipeActions.getEntry());
+
+        mRightVerticalSwipeActions.setValue(Integer.toString(rightVerticalSwipeActions));
+        mRightVerticalSwipeActions.setSummary(mRightVerticalSwipeActions.getEntry());
+
+        mLeftVerticalSwipeAppSelection.setVisible(mExtendedSwipe.isChecked() && mLeftVerticalSwipeActions.getEntryValues()
+                [leftVerticalSwipeActions].equals("4"));
+        mRightVerticalSwipeAppSelection.setVisible(mExtendedSwipe.isChecked() && mRightVerticalSwipeActions.getEntryValues()
+                [rightVerticalSwipeActions].equals("4"));
+    }
+
+    private void customAppCheck() {
+        mLeftSwipeAppSelection.setSummary(Settings.System.getStringForUser(getContentResolver(),
+                String.valueOf(Settings.System.LEFT_LONG_BACK_SWIPE_APP_FR_ACTION), UserHandle.USER_CURRENT));
+        mRightSwipeAppSelection.setSummary(Settings.System.getStringForUser(getContentResolver(),
+                String.valueOf(Settings.System.RIGHT_LONG_BACK_SWIPE_APP_FR_ACTION), UserHandle.USER_CURRENT));
+
+        mLeftVerticalSwipeAppSelection.setSummary(Settings.System.getStringForUser(getContentResolver(),
+                String.valueOf(Settings.System.LEFT_VERTICAL_BACK_SWIPE_APP_FR_ACTION), UserHandle.USER_CURRENT));
+        mRightVerticalSwipeAppSelection.setSummary(Settings.System.getStringForUser(getContentResolver(),
+                String.valueOf(Settings.System.RIGHT_VERTICAL_BACK_SWIPE_APP_FR_ACTION), UserHandle.USER_CURRENT));
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsProto.MetricsEvent.EVO_SETTINGS;
+    }
+
+    public static final SearchIndexProvider SEARCH_INDEX_DATA_PROVIDER =
+            new BaseSearchIndexProvider() {
+                @Override
+                public List<SearchIndexableResource> getXmlResourcesToIndex(Context context,
+                        boolean enabled) {
+                    ArrayList<SearchIndexableResource> result = new ArrayList<>();
+                    SearchIndexableResource sir = new SearchIndexableResource(context);
+                    sir.xmlResId = R.xml.gesture_nav_tweaks;
+                    result.add(sir);
+                    return result;
+                }
+
+                @Override
+                public List<String> getNonIndexableKeys(Context context) {
+                    List<String> keys = super.getNonIndexableKeys(context);
+                    return keys;
+                }
+            };
+}

--- a/src/com/android/settings/gestures/GestureTweaksSettings.java
+++ b/src/com/android/settings/gestures/GestureTweaksSettings.java
@@ -27,7 +27,8 @@ import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceScreen;
 import androidx.preference.Preference.OnPreferenceChangeListener;
-import androidx.preference.SwitchPreference;
+import androidx.preference.SwitchPreferenceCompat;
+import androidx.preference.TwoStatePreference;
 
 import com.android.internal.logging.nano.MetricsProto;
 

--- a/src/com/android/settings/gestures/PowerMenuSettingsUtils.java
+++ b/src/com/android/settings/gestures/PowerMenuSettingsUtils.java
@@ -55,6 +55,7 @@ final class PowerMenuSettingsUtils {
     private static final int LONG_PRESS_POWER_GLOBAL_ACTIONS = 1; // a.k.a., Power Menu
     private static final int LONG_PRESS_POWER_ASSISTANT_VALUE = 5; // Settings.Secure.ASSISTANT
 
+    private static final int KEY_CHORD_POWER_VOLUME_UP_MUTE_TOGGLE = 1;
     private static final int KEY_CHORD_POWER_VOLUME_UP_GLOBAL_ACTIONS = 2;
 
     private static final Uri POWER_BUTTON_LONG_PRESS_URI =
@@ -113,14 +114,11 @@ final class PowerMenuSettingsUtils {
                 context.getContentResolver(),
                 POWER_BUTTON_LONG_PRESS_SETTING,
                 LONG_PRESS_POWER_GLOBAL_ACTIONS)) {
-            // We restore power + volume up buttons to the default action.
-            int keyChordDefaultValue =
-                    context.getResources()
-                            .getInteger(KEY_CHORD_POWER_VOLUME_UP_DEFAULT_VALUE_RESOURCE);
+            // We restore power + volume up buttons to the mute action.
             Settings.Global.putInt(
                     context.getContentResolver(),
                     KEY_CHORD_POWER_VOLUME_UP_SETTING,
-                    keyChordDefaultValue);
+                    KEY_CHORD_POWER_VOLUME_UP_MUTE_TOGGLE);
             return true;
         }
         return false;

--- a/src/com/android/settings/gestures/PreventRingingGesturePreferenceController.java
+++ b/src/com/android/settings/gestures/PreventRingingGesturePreferenceController.java
@@ -31,7 +31,8 @@ import android.provider.Settings;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceScreen;
-import androidx.preference.SwitchPreference;
+import androidx.preference.SwitchPreferenceCompat;
+import androidx.preference.TwoStatePreference;
 
 import com.android.settings.R;
 import com.android.settings.core.PreferenceControllerMixin;
@@ -64,9 +65,9 @@ public class PreventRingingGesturePreferenceController extends AbstractPreferenc
 
     PreferenceCategory mPreferenceCategory;
     MainSwitchPreference mMasterSwitch;
-    SwitchPreference mNormalPref;
-    SwitchPreference mVibratePref;
-    SwitchPreference mMutePref;
+    TwoStatePreference mNormalPref;
+    TwoStatePreference mVibratePref;
+    TwoStatePreference mMutePref;
 
     private SettingObserver mSettingObserver;
 
@@ -202,8 +203,8 @@ public class PreventRingingGesturePreferenceController extends AbstractPreferenc
         }
     }
 
-    private SwitchPreference makeSwitchPreference(String key, int titleId) {
-        SwitchPreference pref = new SwitchPreference(mPreferenceCategory.getContext());
+    private TwoStatePreference makeSwitchPreference(String key, int titleId) {
+        TwoStatePreference pref = new SwitchPreferenceCompat(mPreferenceCategory.getContext());
         pref.setKey(key);
         pref.setTitle(titleId);
         pref.setOnPreferenceChangeListener(this);

--- a/src/com/android/settings/gestures/PreventRingingSwitchPreferenceController.java
+++ b/src/com/android/settings/gestures/PreventRingingSwitchPreferenceController.java
@@ -24,7 +24,8 @@ import android.widget.CompoundButton.OnCheckedChangeListener;
 import androidx.annotation.VisibleForTesting;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceScreen;
-import androidx.preference.SwitchPreference;
+import androidx.preference.SwitchPreferenceCompat;
+import androidx.preference.TwoStatePreference;
 
 import com.android.settings.R;
 import com.android.settings.core.PreferenceControllerMixin;
@@ -39,7 +40,7 @@ public class PreventRingingSwitchPreferenceController extends AbstractPreference
     private final Context mContext;
 
     MainSwitchPreference mSwitch;
-    SwitchPreference mVibratePref;
+    TwoStatePreference mVibratePref;
 
     public PreventRingingSwitchPreferenceController(Context context) {
         super(context);

--- a/src/com/android/settings/gestures/SystemNavigationPreferenceController.java
+++ b/src/com/android/settings/gestures/SystemNavigationPreferenceController.java
@@ -27,6 +27,8 @@ import android.content.pm.PackageManager;
 import com.android.settings.R;
 import com.android.settings.core.BasePreferenceController;
 
+import com.android.internal.util.custom.NavbarUtils;
+
 public class SystemNavigationPreferenceController extends BasePreferenceController {
 
     static final String PREF_KEY_SYSTEM_NAVIGATION = "gesture_system_navigation";
@@ -72,6 +74,11 @@ public class SystemNavigationPreferenceController extends BasePreferenceControll
                 .setPackage(recentsComponentName.getPackageName());
         if (context.getPackageManager().resolveService(quickStepIntent,
                 PackageManager.MATCH_SYSTEM_ONLY) == null) {
+            return false;
+        }
+
+        // Check if navbar visible
+        if (!NavbarUtils.isEnabled(context)){
             return false;
         }
 

--- a/src/com/android/settings/network/NetworkProviderSettings.java
+++ b/src/com/android/settings/network/NetworkProviderSettings.java
@@ -36,6 +36,7 @@ import android.os.PowerManager;
 import android.os.UserHandle;
 import android.os.UserManager;
 import android.provider.Settings;
+import android.telephony.SubscriptionManager;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 import android.util.EventLog;
@@ -68,6 +69,7 @@ import com.android.settings.core.SubSettingLauncher;
 import com.android.settings.datausage.DataUsagePreference;
 import com.android.settings.datausage.DataUsageUtils;
 import com.android.settings.location.WifiScanningFragment;
+import com.android.settings.network.MobileDataEnabledListener;
 import com.android.settings.search.BaseSearchIndexProvider;
 import com.android.settings.wifi.AddNetworkFragment;
 import com.android.settings.wifi.AddWifiNetworkPreference;
@@ -110,7 +112,8 @@ import java.util.Optional;
 public class NetworkProviderSettings extends RestrictedSettingsFragment
         implements Indexable, WifiPickerTracker.WifiPickerTrackerCallback,
         WifiDialog2.WifiDialog2Listener, DialogInterface.OnDismissListener,
-        AirplaneModeEnabler.OnAirplaneModeChangedListener, InternetUpdater.InternetChangeListener {
+        AirplaneModeEnabler.OnAirplaneModeChangedListener, InternetUpdater.InternetChangeListener,
+        MobileDataEnabledListener.Client {
 
     public static final String ACTION_NETWORK_PROVIDER_SETTINGS =
             "android.settings.NETWORK_PROVIDER_SETTINGS";
@@ -206,6 +209,9 @@ public class NetworkProviderSettings extends RestrictedSettingsFragment
     protected WifiManager mWifiManager;
     private WifiManager.ActionListener mSaveListener;
 
+    int mSubId = SubscriptionManager.INVALID_SUBSCRIPTION_ID;
+    MobileDataEnabledListener mDataStateListener;
+
     protected InternetResetHelper mInternetResetHelper;
 
     /**
@@ -269,6 +275,7 @@ public class NetworkProviderSettings extends RestrictedSettingsFragment
 
     public NetworkProviderSettings() {
         super(DISALLOW_CONFIG_WIFI);
+        mSubId = SubscriptionManager.getActiveDataSubscriptionId();
     }
 
     @Override
@@ -313,6 +320,7 @@ public class NetworkProviderSettings extends RestrictedSettingsFragment
     public void onCreate(Bundle icicle) {
         super.onCreate(icicle);
         mAirplaneModeEnabler = new AirplaneModeEnabler(getContext(), this);
+        mDataStateListener = new MobileDataEnabledListener(getContext(), this);
 
         // TODO(b/37429702): Add animations and preference comparator back after initial screen is
         // loaded (ODR).
@@ -533,6 +541,7 @@ public class NetworkProviderSettings extends RestrictedSettingsFragment
             return;
         }
         mAirplaneModeEnabler.start();
+        mDataStateListener.start(mSubId);
     }
 
     private void restrictUi() {
@@ -561,7 +570,8 @@ public class NetworkProviderSettings extends RestrictedSettingsFragment
         }
 
         changeNextButtonState(mWifiPickerTracker != null
-                && mWifiPickerTracker.getConnectedWifiEntry() != null);
+                && mWifiPickerTracker.getConnectedWifiEntry() != null
+                || getDataEnabled());
     }
 
     @Override
@@ -570,6 +580,7 @@ public class NetworkProviderSettings extends RestrictedSettingsFragment
         getView().removeCallbacks(mUpdateWifiEntryPreferencesRunnable);
         getView().removeCallbacks(mHideProgressBarRunnable);
         mAirplaneModeEnabler.stop();
+        mDataStateListener.stop();
         super.onStop();
     }
 
@@ -948,7 +959,8 @@ public class NetworkProviderSettings extends RestrictedSettingsFragment
             setProgressBarVisible(false);
         }
         changeNextButtonState(mWifiPickerTracker != null
-                && mWifiPickerTracker.getConnectedWifiEntry() != null);
+                && mWifiPickerTracker.getConnectedWifiEntry() != null
+                || getDataEnabled());
 
         // Edit the Wi-Fi network of specified SSID.
         if (mOpenSsid != null && mWifiPickerTracker != null) {
@@ -1235,7 +1247,7 @@ public class NetworkProviderSettings extends RestrictedSettingsFragment
      * Renames/replaces "Next" button when appropriate. "Next" button usually exists in
      * Wi-Fi setup screens, not in usual wifi settings screen.
      *
-     * @param enabled true when the device is connected to a wifi network.
+     * @param enabled true when the device is connected to a mobile or wifi network.
      */
     @VisibleForTesting
     void changeNextButtonState(boolean enabled) {
@@ -1502,6 +1514,17 @@ public class NetworkProviderSettings extends RestrictedSettingsFragment
             // update the menu item
             requireActivity().invalidateMenu();
         }
+    }
+
+    /**
+     * Implementation of {@code MobileDataEnabledListener.Client}
+     */
+    public void onMobileDataEnabledChange() {
+        changeNextButtonState(getDataEnabled());
+    }
+
+    boolean getDataEnabled() {
+        return getContext().getSystemService(TelephonyManager.class).getDataEnabled(mSubId);
     }
 
     /**

--- a/src/com/android/settings/network/telephony/ForceLteCaPreferenceController.java
+++ b/src/com/android/settings/network/telephony/ForceLteCaPreferenceController.java
@@ -12,7 +12,8 @@ import android.util.Log;
 import androidx.annotation.VisibleForTesting;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceScreen;
-import androidx.preference.SwitchPreference;
+import androidx.preference.SwitchPreferenceCompat;
+import androidx.preference.TwoStatePreference;
 
 import com.android.internal.telephony.util.ArrayUtils;
 import com.android.settingslib.core.lifecycle.LifecycleObserver;
@@ -105,7 +106,7 @@ public class ForceLteCaPreferenceController extends TelephonyTogglePreferenceCon
         if (preference == null) {
             return;
         }
-        final SwitchPreference switchPreference = (SwitchPreference) preference;
+        final TwoStatePreference switchPreference = (TwoStatePreference) preference;
         switchPreference.setEnabled(isUserControlAllowed());
     }
 

--- a/src/com/android/settings/network/telephony/MobileDataPreferenceController.java
+++ b/src/com/android/settings/network/telephony/MobileDataPreferenceController.java
@@ -20,6 +20,7 @@ import static androidx.lifecycle.Lifecycle.Event.ON_START;
 import static androidx.lifecycle.Lifecycle.Event.ON_STOP;
 
 import android.content.Context;
+import android.provider.Settings;
 import android.telephony.SubscriptionManager;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
@@ -39,6 +40,8 @@ import com.android.settings.wifi.WifiPickerTrackerHelper;
 import com.android.settingslib.core.lifecycle.Lifecycle;
 import com.android.settingslib.mobile.dataservice.MobileNetworkInfoEntity;
 import com.android.settingslib.mobile.dataservice.SubscriptionInfoEntity;
+
+import com.google.android.setupcompat.util.WizardManagerHelper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -120,6 +123,14 @@ public class MobileDataPreferenceController extends TelephonyTogglePreferenceCon
     @Override
     public boolean setChecked(boolean isChecked) {
         mNeedDialog = isDialogNeeded();
+
+        // If we are still provisioning we need to allow enabling mobile data first.
+        // By default it is not allowed to use mobile network during provisioning so
+        // we need to allow it.
+        if (!WizardManagerHelper.isDeviceProvisioned(mContext)) {
+            Settings.Global.putInt(mContext.getContentResolver(),
+                    Settings.Global.DEVICE_PROVISIONING_MOBILE_DATA_ENABLED, isChecked ? 1 : 0);
+        }
 
         if (!mNeedDialog) {
             // Update data directly if we don't need dialog

--- a/src/com/android/settings/notification/NFCSoundsPreferenceController.java
+++ b/src/com/android/settings/notification/NFCSoundsPreferenceController.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Yet Another AOSP Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.notification;
+
+import static com.android.settings.notification.SettingPref.TYPE_SECURE;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.provider.Settings.Secure;
+import android.nfc.NfcAdapter;
+
+import com.android.settings.SettingsPreferenceFragment;
+import com.android.settingslib.core.lifecycle.Lifecycle;
+
+public class NFCSoundsPreferenceController extends SettingPrefController {
+
+    private static final String KEY = "nfc_sounds";
+
+    public NFCSoundsPreferenceController(Context context, SettingsPreferenceFragment parent,
+            Lifecycle lifecycle) {
+        super(context, parent, lifecycle);
+        mPreference = new SettingPref(
+            TYPE_SECURE, KEY, Secure.NFC_SOUNDS, DEFAULT_ON) {
+            @Override
+            public boolean isApplicable(Context context) {
+                final PackageManager pm = context.getPackageManager();
+                if (!pm.hasSystemFeature(PackageManager.FEATURE_NFC))
+                    return false;
+                if (NfcAdapter.getDefaultAdapter(context) == null)
+                    return false;
+                return true;
+            }
+        };
+    }
+
+}

--- a/src/com/android/settings/notification/NotificationBackend.java
+++ b/src/com/android/settings/notification/NotificationBackend.java
@@ -93,6 +93,7 @@ public class NotificationBackend {
         row.userId = UserHandle.getUserId(row.uid);
         row.blockedChannelCount = getBlockedChannelCount(row.pkg, row.uid);
         row.channelCount = getChannelCount(row.pkg, row.uid);
+        row.soundTimeout = getNotificationSoundTimeout(row.pkg, row.uid);
         recordAggregatedUsageEvents(context, row);
         return row;
     }
@@ -641,6 +642,25 @@ public class NotificationBackend {
         sINM = inm;
     }
 
+    public long getNotificationSoundTimeout(String pkg, int uid) {
+        try {
+            return sINM.getNotificationSoundTimeout(pkg, uid);
+        } catch (Exception e) {
+            Log.w(TAG, "Error calling NoMan", e);
+            return 0;
+        }
+    }
+
+    public boolean setNotificationSoundTimeout(String pkg, int uid, long timeout) {
+        try {
+            sINM.setNotificationSoundTimeout(pkg, uid, timeout);
+            return true;
+        } catch (Exception e) {
+            Log.w(TAG, "Error calling NoMan", e);
+            return false;
+        }
+    }
+
     /**
      * NotificationsSentState contains how often an app sends notifications and how recently it sent
      * one.
@@ -674,6 +694,7 @@ public class NotificationBackend {
         public int userId;
         public int blockedChannelCount;
         public int channelCount;
+        public long soundTimeout;
         public Map<String, NotificationsSentState> sentByChannel;
         public NotificationsSentState sentByApp;
     }

--- a/src/com/android/settings/notification/PhoneRingtone2PreferenceController.java
+++ b/src/com/android/settings/notification/PhoneRingtone2PreferenceController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 The Android Open Source Project
+ * Copyright (C) 2018 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,21 +18,19 @@ package com.android.settings.notification;
 
 import android.content.Context;
 import android.media.RingtoneManager;
-
 import android.telephony.TelephonyManager;
 
 import androidx.preference.PreferenceScreen;
 
 import com.android.settings.DefaultRingtonePreference;
-import com.android.settings.R;
-
 import com.android.settings.Utils;
 
-public class PhoneRingtonePreferenceController extends RingtonePreferenceControllerBase {
+public class PhoneRingtone2PreferenceController extends RingtonePreferenceControllerBase {
 
-    private static final String KEY_PHONE_RINGTONE = "phone_ringtone";
+    private static final int SLOT_ID = 1;
+    private static final String KEY_PHONE_RINGTONE2 = "ringtone2";
 
-    public PhoneRingtonePreferenceController(Context context) {
+    public PhoneRingtone2PreferenceController(Context context) {
         super(context);
     }
 
@@ -40,24 +38,21 @@ public class PhoneRingtonePreferenceController extends RingtonePreferenceControl
     public void displayPreference(PreferenceScreen screen) {
         super.displayPreference(screen);
 
-        TelephonyManager telephonyManager =
-                (TelephonyManager) mContext.getSystemService(Context.TELEPHONY_SERVICE);
-        if (telephonyManager.isMultiSimEnabled()) {
-            // For Multi SIM device, shoud show "Phone ringtone - SIM 1" for slot1 ringtone setting.
-            DefaultRingtonePreference ringtonePreference =
-                    (DefaultRingtonePreference) screen.findPreference(KEY_PHONE_RINGTONE);
-            ringtonePreference.setTitle(mContext.getString(R.string.ringtone1_title));
-        }
+        DefaultRingtonePreference ringtonePreference =
+                (DefaultRingtonePreference) screen.findPreference(KEY_PHONE_RINGTONE2);
+        ringtonePreference.setSlotId(SLOT_ID);
     }
 
     @Override
     public String getPreferenceKey() {
-        return KEY_PHONE_RINGTONE;
+        return KEY_PHONE_RINGTONE2;
     }
 
     @Override
     public boolean isAvailable() {
-        return Utils.isVoiceCapable(mContext);
+        TelephonyManager telephonyManager =
+                (TelephonyManager) mContext.getSystemService(Context.TELEPHONY_SERVICE);
+        return Utils.isVoiceCapable(mContext) && telephonyManager.isMultiSimEnabled();
     }
 
     @Override

--- a/src/com/android/settings/notification/RingtonePreferenceControllerBase.java
+++ b/src/com/android/settings/notification/RingtonePreferenceControllerBase.java
@@ -24,6 +24,7 @@ import android.util.Log;
 
 import androidx.preference.Preference;
 
+import com.android.settings.RingtonePreference;
 import com.android.settings.core.PreferenceControllerMixin;
 import com.android.settingslib.core.AbstractPreferenceController;
 import com.android.settingslib.utils.ThreadUtils;
@@ -51,8 +52,8 @@ public abstract class RingtonePreferenceControllerBase extends AbstractPreferenc
     }
 
     private void updateSummary(Preference preference) {
-        final Uri ringtoneUri = RingtoneManager.getActualDefaultRingtoneUri(
-                mContext, getRingtoneType());
+        final Uri ringtoneUri = RingtoneManager.getActualDefaultRingtoneUriBySlot(mContext,
+                getRingtoneType(), ((RingtonePreference)preference).getSlotId());
 
         final CharSequence summary;
         try {

--- a/src/com/android/settings/notification/SoundSettings.java
+++ b/src/com/android/settings/notification/SoundSettings.java
@@ -286,6 +286,7 @@ public class SoundSettings extends DashboardFragment implements OnActivityResult
 
         // === Phone & notification ringtone ===
         controllers.add(new PhoneRingtonePreferenceController(context));
+        controllers.add(new PhoneRingtone2PreferenceController(context));
         controllers.add(new AlarmRingtonePreferenceController(context));
         controllers.add(new NotificationRingtonePreferenceController(context));
         controllers.add(new IncreasingRingPreferenceController(context));

--- a/src/com/android/settings/notification/SoundSettings.java
+++ b/src/com/android/settings/notification/SoundSettings.java
@@ -303,6 +303,8 @@ public class SoundSettings extends DashboardFragment implements OnActivityResult
                 new DockingSoundPreferenceController(context, fragment, lifecycle);
         final TouchSoundPreferenceController touchSoundPreferenceController =
                 new TouchSoundPreferenceController(context, fragment, lifecycle);
+        final NFCSoundsPreferenceController nfcSoundsPreferenceController =
+                new NFCSoundsPreferenceController(context, fragment, lifecycle);
         final DockAudioMediaPreferenceController dockAudioMediaPreferenceController =
                 new DockAudioMediaPreferenceController(context, fragment, lifecycle);
         final BootSoundPreferenceController bootSoundPreferenceController =
@@ -317,6 +319,7 @@ public class SoundSettings extends DashboardFragment implements OnActivityResult
         controllers.add(chargingSoundPreferenceController);
         controllers.add(dockingSoundPreferenceController);
         controllers.add(touchSoundPreferenceController);
+        controllers.add(nfcSoundsPreferenceController);
         controllers.add(vibrateIconPreferenceController);
         controllers.add(dockAudioMediaPreferenceController);
         controllers.add(bootSoundPreferenceController);
@@ -328,6 +331,7 @@ public class SoundSettings extends DashboardFragment implements OnActivityResult
                         chargingSoundPreferenceController,
                         dockingSoundPreferenceController,
                         touchSoundPreferenceController,
+                        nfcSoundsPreferenceController,
                         vibrateIconPreferenceController,
                         dockAudioMediaPreferenceController,
                         bootSoundPreferenceController,

--- a/src/com/android/settings/notification/app/AppNotificationSettings.java
+++ b/src/com/android/settings/notification/app/AppNotificationSettings.java
@@ -76,6 +76,7 @@ public class AppNotificationSettings extends NotificationSettings {
         mControllers.add(new BlockPreferenceController(context, mDependentFieldListener, mBackend));
         mControllers.add(new FullScreenIntentPermissionPreferenceController(context, mBackend));
         mControllers.add(new BadgePreferenceController(context, mBackend));
+        mControllers.add(new SoundTimeoutPreferenceController(context, mBackend));
         mControllers.add(new AllowSoundPreferenceController(
                 context, mDependentFieldListener, mBackend));
         mControllers.add(new ImportancePreferenceController(

--- a/src/com/android/settings/notification/app/SoundTimeoutPreferenceController.java
+++ b/src/com/android/settings/notification/app/SoundTimeoutPreferenceController.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2019 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.notification.app;
+
+import android.content.Context;
+import android.provider.Settings;
+
+import androidx.preference.Preference;
+
+import com.android.settings.RestrictedListPreference;
+import com.android.settings.core.PreferenceControllerMixin;
+import com.android.settings.notification.NotificationBackend;
+
+public class SoundTimeoutPreferenceController extends NotificationPreferenceController
+        implements PreferenceControllerMixin, Preference.OnPreferenceChangeListener {
+
+    private static final String TAG = "SoundTimeoutPreferenceController";
+    private static final String KEY_SOUND_TIMEOUT = "sound_timeout";
+
+    public SoundTimeoutPreferenceController(Context context,
+            NotificationBackend backend) {
+        super(context, backend);
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return KEY_SOUND_TIMEOUT;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        if (!super.isAvailable()) {
+            return false;
+        }
+        if (mAppRow == null) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    boolean isIncludedInFilter() {
+        return false;
+    }
+
+    public void updateState(Preference preference) {
+        if (mAppRow != null) {
+            RestrictedListPreference pref = (RestrictedListPreference) preference;
+            pref.setDisabledByAdmin(mAdmin);
+
+            pref.setSummary("%s");
+            pref.setValue(Long.toString(mAppRow.soundTimeout));
+        }
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        if (mAppRow != null) {
+            mAppRow.soundTimeout = Long.valueOf((String) newValue);
+            mBackend.setNotificationSoundTimeout(mAppRow.pkg, mAppRow.uid, mAppRow.soundTimeout);
+        }
+        return true;
+    }
+
+}

--- a/src/com/android/settings/password/ChooseLockPassword.java
+++ b/src/com/android/settings/password/ChooseLockPassword.java
@@ -229,7 +229,7 @@ public class ChooseLockPassword extends SettingsActivity {
         private static final String KEY_IS_AUTO_CONFIRM_CHECK_MANUALLY_CHANGED =
                 "auto_confirm_option_set_manually";
 
-        private static final int MIN_AUTO_PIN_REQUIREMENT_LENGTH = 6;
+        private static final int MIN_AUTO_PIN_REQUIREMENT_LENGTH = 4;
 
         private LockscreenCredential mCurrentCredential;
         private LockscreenCredential mChosenPassword;

--- a/src/com/android/settings/password/ChooseLockPassword.java
+++ b/src/com/android/settings/password/ChooseLockPassword.java
@@ -977,7 +977,7 @@ public class ChooseLockPassword extends SettingsActivity {
                 mAutoPinConfirmOption.setVisibility(View.VISIBLE);
                 mAutoConfirmSecurityMessage.setVisibility(View.VISIBLE);
                 if (!mIsAutoPinConfirmOptionSetManually) {
-                    mAutoPinConfirmOption.setChecked(length == MIN_AUTO_PIN_REQUIREMENT_LENGTH);
+                    mAutoPinConfirmOption.setChecked(length >= MIN_AUTO_PIN_REQUIREMENT_LENGTH);
                 }
             } else {
                 mAutoPinConfirmOption.setVisibility(View.GONE);

--- a/src/com/android/settings/security/HideDeveloperStatusSettings.kt
+++ b/src/com/android/settings/security/HideDeveloperStatusSettings.kt
@@ -60,7 +60,7 @@ class HideDeveloperStatusSettings: Fragment(R.layout.hide_developer_status_layou
     private lateinit var userManager: UserManager
     private lateinit var userInfos: List<UserInfo>
 
-    private var appBarLayout: AppBarLayout? = requireActivity().findViewById(R.id.app_bar)
+    private var appBarLayout: AppBarLayout? = null
     private var searchText = ""
     private var customFilter: ((PackageInfo) -> Boolean)? = null
     private var comparator: ((PackageInfo, PackageInfo) -> Int)? = null
@@ -82,6 +82,7 @@ class HideDeveloperStatusSettings: Fragment(R.layout.hide_developer_status_layou
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
         requireActivity().setTitle(getTitle())
+        appBarLayout = requireActivity().findViewById(R.id.app_bar)
         activityManager = requireContext().getSystemService(ActivityManager::class.java) as ActivityManager
         packageManager = requireContext().packageManager
         packageList = packageManager.getInstalledPackages(PackageManager.MATCH_ANY_USER)

--- a/src/com/android/settings/sound/AdaptivePlaybackSoundPreferenceController.java
+++ b/src/com/android/settings/sound/AdaptivePlaybackSoundPreferenceController.java
@@ -34,10 +34,10 @@ import com.android.settings.core.BasePreferenceController;
 import com.android.settingslib.core.lifecycle.LifecycleObserver;
 import com.android.settingslib.core.lifecycle.events.OnStart;
 import com.android.settingslib.core.lifecycle.events.OnStop;
-import com.android.settingslib.widget.RadioButtonPreference;
+import com.android.settingslib.widget.SelectorWithWidgetPreference;
 
 public class AdaptivePlaybackSoundPreferenceController extends BasePreferenceController
-        implements RadioButtonPreference.OnClickListener, LifecycleObserver, OnStart, OnStop {
+        implements SelectorWithWidgetPreference.OnClickListener, LifecycleObserver, OnStart, OnStop {
 
     private static final String KEY_NO_TIMEOUT = "adaptive_playback_timeout_none";
     private static final String KEY_30_SECS = "adaptive_playback_timeout_30_secs";
@@ -57,12 +57,12 @@ public class AdaptivePlaybackSoundPreferenceController extends BasePreferenceCon
     private int mAdaptivePlaybackTimeout;
 
     private PreferenceCategory mPreferenceCategory;
-    private RadioButtonPreference mTimeoutNonePref;
-    private RadioButtonPreference mTimeout30SecPref;
-    private RadioButtonPreference mTimeout1MinPref;
-    private RadioButtonPreference mTimeout2MinPref;
-    private RadioButtonPreference mTimeout5MinPref;
-    private RadioButtonPreference mTimeout10MinPref;
+    private SelectorWithWidgetPreference mTimeoutNonePref;
+    private SelectorWithWidgetPreference mTimeout30SecPref;
+    private SelectorWithWidgetPreference mTimeout1MinPref;
+    private SelectorWithWidgetPreference mTimeout2MinPref;
+    private SelectorWithWidgetPreference mTimeout5MinPref;
+    private SelectorWithWidgetPreference mTimeout10MinPref;
 
     private final SettingObserver mSettingObserver;
 
@@ -100,7 +100,7 @@ public class AdaptivePlaybackSoundPreferenceController extends BasePreferenceCon
     }
 
     @Override
-    public void onRadioButtonClicked(RadioButtonPreference preference) {
+    public void onRadioButtonClicked(SelectorWithWidgetPreference preference) {
         int adaptivePlaybackTimeout = keyToSetting(preference.getKey());
         if (adaptivePlaybackTimeout != Settings.System.getIntForUser(mContext.getContentResolver(),
                 Settings.System.ADAPTIVE_PLAYBACK_TIMEOUT, ADAPTIVE_PLAYBACK_TIMEOUT_30_SECS,
@@ -190,8 +190,9 @@ public class AdaptivePlaybackSoundPreferenceController extends BasePreferenceCon
         }
     }
 
-    private RadioButtonPreference makeRadioPreference(String key, int titleId) {
-        RadioButtonPreference pref = new RadioButtonPreference(mPreferenceCategory.getContext());
+    private SelectorWithWidgetPreference makeRadioPreference(String key, int titleId) {
+        SelectorWithWidgetPreference pref = new SelectorWithWidgetPreference(
+                mPreferenceCategory.getContext());
         pref.setKey(key);
         pref.setTitle(titleId);
         pref.setOnClickListener(this);

--- a/src/com/android/settings/sound/CustomHapticPreferenceController.java
+++ b/src/com/android/settings/sound/CustomHapticPreferenceController.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2019 The PixelExperience Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.sound;
+
+import android.content.Context;
+import android.os.Vibrator;
+
+import com.android.settings.core.BasePreferenceController;
+
+public class CustomHapticPreferenceController extends BasePreferenceController {
+
+    private final boolean mHasVibrator;
+
+    public CustomHapticPreferenceController(Context context, String key) {
+        super(context, key);
+        mHasVibrator = context.getSystemService(Vibrator.class).hasVibrator();
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return mHasVibrator ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+    }
+
+}

--- a/src/com/android/settings/sound/IncallFeedbackPreferenceController.java
+++ b/src/com/android/settings/sound/IncallFeedbackPreferenceController.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019 The PixelExperience Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.sound;
+
+import android.content.Context;
+import android.telephony.TelephonyManager;
+
+import com.android.settings.core.BasePreferenceController;
+
+public class IncallFeedbackPreferenceController extends BasePreferenceController {
+
+    public IncallFeedbackPreferenceController(Context context, String key) {
+        super(context, key);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return isVoiceCapable() ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+    }
+
+    private boolean isVoiceCapable() {
+        TelephonyManager telephony =
+                (TelephonyManager) mContext.getSystemService(Context.TELEPHONY_SERVICE);
+        return telephony != null && telephony.isVoiceCapable();
+    }
+
+}

--- a/src/com/android/settings/sound/VolumeSteps.java
+++ b/src/com/android/settings/sound/VolumeSteps.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2024 Yet Another AOSP Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.sound;
+
+import android.content.ContentResolver;
+import android.os.Bundle;
+import android.provider.Settings;
+
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.Preference.OnPreferenceChangeListener;
+
+import com.android.internal.logging.nano.MetricsProto;
+import com.android.settings.R;
+import com.android.settings.dashboard.DashboardFragment;
+import com.android.settings.search.BaseSearchIndexProvider;
+import com.android.settingslib.search.SearchIndexable;
+
+import com.evolution.settings.preference.CustomSeekBarPreference;
+
+/**
+ * volume steps settings under sound
+ */
+@SearchIndexable
+public class VolumeSteps extends DashboardFragment implements OnPreferenceChangeListener {
+
+    private static final String TAG = "VolumeSteps";
+
+    @Override
+    protected int getPreferenceScreenResId() {
+        return R.xml.volume_steps_settings;
+    }
+
+    @Override
+    public void onCreate(Bundle icicle) {
+        super.onCreate(icicle);
+
+        ContentResolver resolver = getActivity().getContentResolver();
+        PreferenceScreen screen = getPreferenceScreen();
+        final int count = screen.getPreferenceCount();
+        for (int i = 0; i < count; i++) {
+            Preference pref = screen.getPreference(i);
+            if (!(pref instanceof CustomSeekBarPreference))
+                continue;
+            String key = pref.getKey();
+            final int def = Settings.System.getInt(resolver, "default_" + key, 15);
+            final int value = Settings.System.getInt(resolver, key, def);
+            CustomSeekBarPreference sbPref = (CustomSeekBarPreference) pref;
+            sbPref.setDefaultValue(def);
+            sbPref.setValue(value);
+            sbPref.setOnPreferenceChangeListener(this);
+        }
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        if (!(preference instanceof CustomSeekBarPreference))
+            return false;
+        Settings.System.putInt(getActivity().getContentResolver(),
+                preference.getKey(), (Integer) newValue);
+        return true;
+    }
+
+    @Override
+    protected String getLogTag() {
+        return TAG;
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsProto.MetricsEvent.EVO_SETTINGS;
+    }
+
+    public static final BaseSearchIndexProvider SEARCH_INDEX_DATA_PROVIDER =
+            new BaseSearchIndexProvider(R.xml.volume_steps_settings);
+}

--- a/src/com/android/settings/wifi/details2/WifiDetailPreferenceController2.java
+++ b/src/com/android/settings/wifi/details2/WifiDetailPreferenceController2.java
@@ -747,7 +747,7 @@ public class WifiDetailPreferenceController2 extends AbstractPreferenceControlle
     }
 
     private int getMacAddressTitle() {
-        if (mWifiEntry.getPrivacy() == WifiEntry.PRIVACY_RANDOMIZED_MAC) {
+        if (mWifiEntry.getPrivacy() != WifiEntry.PRIVACY_DEVICE_MAC) {
             return mWifiEntry.getConnectedState() == WifiEntry.CONNECTED_STATE_CONNECTED
                     ? R.string.wifi_advanced_randomized_mac_address_title
                     : R.string.wifi_advanced_randomized_mac_address_disconnected_title;

--- a/src/com/android/settings/wifi/details2/WifiPrivacyPreferenceController2.java
+++ b/src/com/android/settings/wifi/details2/WifiPrivacyPreferenceController2.java
@@ -17,6 +17,7 @@
 package com.android.settings.wifi.details2;
 
 import android.content.Context;
+import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiManager;
 
 import androidx.annotation.NonNull;
@@ -37,6 +38,10 @@ public class WifiPrivacyPreferenceController2 extends BasePreferenceController i
     private static final String KEY_WIFI_PRIVACY = "privacy";
     private final WifiManager mWifiManager;
     private WifiEntry mWifiEntry;
+
+    private static final int PREF_RANDOMIZATION_ALWAYS = 0;
+    private static final int PREF_RANDOMIZATION_PERSISTENT = 1;
+    private static final int PREF_RANDOMIZATION_NONE = 2;
 
     public WifiPrivacyPreferenceController2(Context context) {
         super(context, KEY_WIFI_PRIVACY);
@@ -93,8 +98,6 @@ public class WifiPrivacyPreferenceController2 extends BasePreferenceController i
         return mWifiEntry.getPrivacy();
     }
 
-    private static final int PREF_RANDOMIZATION_PERSISTENT = 0;
-    private static final int PREF_RANDOMIZATION_NONE = 1;
 
     /**
      * Returns preference index value.
@@ -103,8 +106,14 @@ public class WifiPrivacyPreferenceController2 extends BasePreferenceController i
      * @return index value of preference
      */
     public static int translateMacRandomizedValueToPrefValue(int macRandomized) {
-        return (macRandomized == WifiEntry.PRIVACY_RANDOMIZED_MAC)
-            ? PREF_RANDOMIZATION_PERSISTENT : PREF_RANDOMIZATION_NONE;
+        switch (macRandomized) {
+            case WifiEntry.PRIVACY_RANDOMIZED_MAC:
+                return PREF_RANDOMIZATION_PERSISTENT;
+            case WifiEntry.PRIVACY_DEVICE_MAC:
+                return PREF_RANDOMIZATION_NONE;
+            default:
+                return PREF_RANDOMIZATION_ALWAYS;
+        }
     }
 
     /**
@@ -114,8 +123,14 @@ public class WifiPrivacyPreferenceController2 extends BasePreferenceController i
      * @return mac randomized value
      */
     public static int translatePrefValueToMacRandomizedValue(int prefMacRandomized) {
-        return (prefMacRandomized == PREF_RANDOMIZATION_PERSISTENT)
-            ? WifiEntry.PRIVACY_RANDOMIZED_MAC : WifiEntry.PRIVACY_DEVICE_MAC;
+        switch (prefMacRandomized) {
+            case PREF_RANDOMIZATION_PERSISTENT:
+                return WifiEntry.PRIVACY_RANDOMIZED_MAC;
+            case PREF_RANDOMIZATION_NONE:
+                return WifiEntry.PRIVACY_DEVICE_MAC;
+            default:
+                return WifiEntry.PRIVACY_RANDOMIZATION_ALWAYS;
+        }
     }
 
     private void updateSummary(ListPreference preference, int macRandomized) {

--- a/src/ink/kscope/settings/wifi/tether/WifiTetherHiddenSsidPreferenceController.java
+++ b/src/ink/kscope/settings/wifi/tether/WifiTetherHiddenSsidPreferenceController.java
@@ -21,7 +21,8 @@ import android.net.wifi.SoftApConfiguration;
 import android.util.FeatureFlagUtils;
 
 import androidx.preference.Preference;
-import androidx.preference.SwitchPreference;
+import androidx.preference.SwitchPreferenceCompat;
+import androidx.preference.TwoStatePreference;
 
 import com.android.settings.R;
 import com.android.settings.core.FeatureFlags;
@@ -61,7 +62,7 @@ public class WifiTetherHiddenSsidPreferenceController extends
         if (mPreference == null) {
             return;
         }
-        ((SwitchPreference) mPreference).setChecked(mHiddenSsid);
+        ((TwoStatePreference) mPreference).setChecked(mHiddenSsid);
     }
 
     @Override

--- a/tests/robotests/src/com/android/settings/notification/PhoneRingtone2PreferenceControllerTest.java
+++ b/tests/robotests/src/com/android/settings/notification/PhoneRingtone2PreferenceControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 The Android Open Source Project
+ * Copyright (C) 2018 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,21 +25,21 @@ import android.content.Context;
 import android.media.RingtoneManager;
 import android.telephony.TelephonyManager;
 
-import androidx.preference.PreferenceScreen;
+import android.support.v7.preference.PreferenceScreen;
 
 import com.android.settings.DefaultRingtonePreference;
-import com.android.settings.R;
+import com.android.settings.testutils.SettingsRobolectricTestRunner;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadows.ShadowApplication;
 
-@RunWith(RobolectricTestRunner.class)
-public class PhoneRingtonePreferenceControllerTest {
+@RunWith(SettingsRobolectricTestRunner.class)
+public class PhoneRingtone2PreferenceControllerTest {
 
     @Mock
     private TelephonyManager mTelephonyManager;
@@ -49,7 +49,7 @@ public class PhoneRingtonePreferenceControllerTest {
     private DefaultRingtonePreference mPreference;
 
     private Context mContext;
-    private PhoneRingtonePreferenceController mController;
+    private PhoneRingtone2PreferenceController mController;
 
     @Before
     public void setUp() {
@@ -57,18 +57,17 @@ public class PhoneRingtonePreferenceControllerTest {
         ShadowApplication shadowContext = ShadowApplication.getInstance();
         shadowContext.setSystemService(Context.TELEPHONY_SERVICE, mTelephonyManager);
         mContext = RuntimeEnvironment.application;
-        mController = new PhoneRingtonePreferenceController(mContext);
+        mController = new PhoneRingtone2PreferenceController(mContext);
     }
 
     @Test
-    public void displayPreference_shouldUpdateTitle_for_MultiSimDevice() {
-        when(mTelephonyManager.isMultiSimEnabled()).thenReturn(true);
+    public void displayPreference_shouldSetSlotId() {
         when(mPreferenceScreen.findPreference(mController.getPreferenceKey()))
                 .thenReturn(mPreference);
         mController.displayPreference(mPreferenceScreen);
 
-        verify(mPreference).setTitle(mContext.getString(R.string.ringtone1_title));
-    
+        verify(mPreference).setSlotId(1);
+    }
 
     @Test
     public void isAvailable_notVoiceCapable_shouldReturnFalse() {
@@ -78,8 +77,16 @@ public class PhoneRingtonePreferenceControllerTest {
     }
 
     @Test
-    public void isAvailable_VoiceCapable_shouldReturnTrue() {
+    public void isAvailable_notMultiSimEnabled_shouldReturnFalse() {
+        when(mTelephonyManager.isMultiSimEnabled()).thenReturn(false);
+
+        assertThat(mController.isAvailable()).isFalse();
+    }
+
+    @Test
+    public void isAvailable_VoiceCapable_and_MultiSimEnabled_shouldReturnTrue() {
         when(mTelephonyManager.isVoiceCapable()).thenReturn(true);
+        when(mTelephonyManager.isMultiSimEnabled()).thenReturn(true);
 
         assertThat(mController.isAvailable()).isTrue();
     }

--- a/tests/uitests/src/com/android/settings/ui/SoundSettingsTest.java
+++ b/tests/uitests/src/com/android/settings/ui/SoundSettingsTest.java
@@ -21,6 +21,7 @@ import android.os.SystemClock;
 import android.provider.Settings;
 import android.system.helpers.SettingsHelper;
 import android.system.helpers.SettingsHelper.SettingsType;
+import android.telephony.TelephonyManager;
 import android.test.InstrumentationTestCase;
 import android.test.suitebuilder.annotation.MediumTest;
 import android.test.suitebuilder.annotation.Suppress;
@@ -42,6 +43,7 @@ public class SoundSettingsTest extends InstrumentationTestCase {
     private UiDevice mDevice;
     private ContentResolver mResolver;
     private SettingsHelper mHelper;
+    private TelephonyManager mTelephonyManager;
 
 
     private final Map<String, String> ringtoneSounds = Map.of(
@@ -100,6 +102,8 @@ public class SoundSettingsTest extends InstrumentationTestCase {
         mDevice.setOrientationNatural();
         mResolver = getInstrumentation().getContext().getContentResolver();
         mHelper = new SettingsHelper();
+        mTelephonyManager = (TelephonyManager) getInstrumentation().getContext()
+                .getSystemService(Context.TELEPHONY_SERVICE);
     }
 
     @Override
@@ -174,26 +178,49 @@ public class SoundSettingsTest extends InstrumentationTestCase {
     public void testPhoneRingtoneNone() throws Exception {
         launchSoundSettings();
         mHelper.clickSetting("Phone ringtone");
-        verifyRingtone(new RingtoneSetting("None", "null"),
-                Settings.System.RINGTONE);
+        if (mTelephonyManager.isMultiSimEnabled()) {
+            mHelper.clickSetting("Phone ringtone - SIM 1");
+            verifyRingtone(new RingtoneSetting("None", "null"), Settings.System.RINGTONE);
+            mHelper.clickSetting("Phone ringtone - SIM 2");
+            verifyRingtone(new RingtoneSetting("None", "null"), Settings.System.RINGTONE2);
+        } else {
+            mHelper.clickSetting("Phone ringtone");
+            verifyRingtone(new RingtoneSetting("None", "null"), Settings.System.RINGTONE);
+        }
     }
 
     @MediumTest
     @Suppress
     public void testPhoneRingtoneHangouts() throws Exception {
         launchSoundSettings();
-        mHelper.clickSetting("Phone ringtone");
-        verifyRingtone(new RingtoneSetting("Hangouts Call", "31"), Settings.System.RINGTONE);
+        if (mTelephonyManager.isMultiSimEnabled()) {
+            mHelper.clickSetting("Phone ringtone - SIM 1");
+            verifyRingtone(new RingtoneSetting("Hangouts Call", "31"), Settings.System.RINGTONE);
+            mHelper.clickSetting("Phone ringtone - SIM 2");
+            verifyRingtone(new RingtoneSetting("Hangouts Call", "31"), Settings.System.RINGTONE2);
+        } else {
+            mHelper.clickSetting("Phone ringtone");
+            verifyRingtone(new RingtoneSetting("Hangouts Call", "31"), Settings.System.RINGTONE);
+        }
     }
 
     @MediumTest
     public void testPhoneRingtone() throws Exception {
         launchSoundSettings();
-        mHelper.clickSetting("Phone ringtone");
         String ringtone = ringtoneSounds.get(mDevice.getProductName()).toString();
         String ringtoneSettingValue = ringtoneCodes.get(mDevice.getProductName()).toString();
-        verifyRingtone(new RingtoneSetting(ringtone, ringtoneSettingValue),
-                Settings.System.RINGTONE);
+        if (mTelephonyManager.isMultiSimEnabled()) {
+            mHelper.clickSetting("Phone ringtone - SIM 1");
+            verifyRingtone(new RingtoneSetting(ringtone, ringtoneSettingValue),
+                    Settings.System.RINGTONE);
+            mHelper.clickSetting("Phone ringtone - SIM 2");
+            verifyRingtone(new RingtoneSetting(ringtone, ringtoneSettingValue),
+                    Settings.System.RINGTONE2);
+        } else {
+            mHelper.clickSetting("Phone ringtone");
+            verifyRingtone(new RingtoneSetting(ringtone, ringtoneSettingValue),
+                    Settings.System.RINGTONE);
+        }
     }
 
     @MediumTest


### PR DESCRIPTION
## Description:
This adds `fast_charging_title` & `fast_charging_summary` to strings.xml so that it can referred to in the code.

## Bug Logcat:
FAILED: //packages/apps/Settings:Settings aapt2 link [common] Outputs: out/soong/.intermediates/packages/apps/Settings/Settings/android_common/782bb8d1c3056f27f73d5d6bc57b878a/aapt2/package-res.apk out/soong/.intermediates/packages/apps/Settings/Settings/android_common/782bb8d1c3056f27f73d5d6bc57b878a/gen/proguard.options out/soong/.intermediates/packages/apps/Settings/Settings/android_common/782bb8d1c3056f27f73d5d6bc57b878a/R.txt Error: exited with code: 1
Command: out/host/linux-x86/bin/aapt2 link -o out/soong/.intermediates/packages/apps/Settings/Settings/android_common/782bb8d1c3056f27f73d5d6bc57b878a/aapt2/package-res.apk --enable-compact-entries --manifest out/soong/.intermediates/packages/apps/Settings/Settings/android_common/782bb8d1c3056f27f73d5d6bc57b878a/manifest_merger/AndroidManifest.xml  --min-sdk-version 34 --target-sdk-version 34 --version-code 34 --version-name  14 --auto-add-overlay -I out/soong/.intermediates/frameworks/base/core/res/framework-res/android_common/package-res.apk --product nosdcard -c en_US,en_US,af_ZA,am_ET,ar_EG,ar_XB,as_IN,az_AZ,be_BY,bg_BG,bn_BD,bs_BA,ca_ES,cs_CZ,da_DK,de_DE,el_GR,en_AU,en_CA,en_GB,en_IN,en_XA,es_ES,es_US,et_EE,eu_ES,fa_IR,fi_FI,fr_CA,fr_FR,gl_ES,gu_IN,hi_IN,hr_HR,hu_HU,hy_AM,in_ID,is_IS,it_IT,iw_IL,ja_JP,ka_GE,kk_KZ,km_KH,kn_IN,ko_KR,ky_KG,lo_LA,lt_LT,lv_LV,mk_MK,ml_IN,mn_MN,mr_IN,ms_MY,my_MM,nb_NO,ne_NP,nl_NL,or_IN,pa_IN,pl_PL,pt_BR,pt_PT,ro_RO,ru_RU,si_LK,sk_SK,sl_SI,sq_AL,sr_Latn_RS,sr_RS,sv_SE,sw_TZ,ta_IN,te_IN,th_TH,tl_PH,tr_TR,uk_UA,ur_PK,uz_UZ,vi_VN,zh_CN,zh_HK,zh_TW,zu_ZA,en_XC,xxhdpi --preferred-density xxhdpi --no-static-lib-packages --proguard out/soong/.intermediates/packages/apps/Settings/Settings/android_common/782bb8d1c3056f27f73d5d6bc57b878a/gen/proguard.options --output-text-symbols out/soong/.intermediates/packages/apps/Settings/Settings/android_common/782bb8d1c3056f27f73d5d6bc57b878a/R.txt -R @out/soong/.intermediates/packages/apps/Settings/Settings/android_common/782bb8d1c3056f27f73d5d6bc57b878a/aapt2/overlay.list Output:
warn: ignoring density 'xxhdpi-v4' for -c option.
packages/apps/Settings/res/xml/power_usage_summary.xml:62: error: resource string/fast_charging_summary (aka com.android.settings:string/fast_charging_summary) not found. packages/apps/Settings/res/xml/power_usage_summary.xml:62: error: resource string/fast_charging_title (aka com.android.settings:string/fast_charging_title) not found. error: failed linking file resources.